### PR TITLE
Remove recursion from VPTree

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,45 +9,55 @@
 </div>
 
 
-Barnes-Hut implementation of t-SNE written in Rust. The algorithm is described with fine detail in [this paper](http://lvdmaaten.github.io/publications/papers/JMLR_2014.pdf) by Laurens van der Maaten.
+Barnes-Hut and vanilla implementations of the t-SNE algorithm written in Rust. The tree-accelerated version of the algorithm is described with fine detail in [this paper](http://lvdmaaten.github.io/publications/papers/JMLR_2014.pdf) by [Laurens van der Maaten](https://github.com/lvdmaaten). The vanilla version of the algorithm is described in [this other paper](https://www.jmlr.org/papers/volume9/vandermaaten08a/vandermaaten08a.pdf) by G. Hinton and Laurens van der Maaten.
+Additional implementations of the algorithm, including this one, are listed at [this page](http://lvdmaaten.github.io/tsne/).
 
-## Installation 
+## Usage 
 
 Add this line to your `Cargo.toml`:
 ```toml
 [dependencies]
 bhtsne = "0.4.0"
 ```
+### Documentation
 
-## Example
+The docs are available on [crates.io](https://crates.io/crates/bhtsne).
+
+### Example
 
 ```rust
-use bhtsne;
+ use bhtsne;
 
-// Parameters template. One can also use f64s.
-let n: usize = 8;     // Number of vectors to embed.
-let d: usize = 4;     // The dimensionality of the original space.
-let theta: f32 = 0.5; // The parameter used by the Barnes-Hut algorithm. When set to 0.0
-                      // the exact t-SNE version is used instead.
-   
-let perplexity: f32 = 1.0;      // The perplexity of the conditional distribution.
-let max_iter: u64 = 2000;       // The number of fitting iterations.
-let no_dims: usize = 2;         // The dimensionality of the embedded space.
+ const N: usize = 150;         // Number of vectors to embed.
+ const D: usize = 4;           // The dimensionality of the
+                               // original space.
+ const THETA: f32 = 0.5;       // Parameter used by the Barnes-Hut algorithm.
+                               // When set to 0.0 the exact t-SNE version is
+                               // used instead.
+    
+ const PERPLEXITY: f32 = 10.0; // Perplexity of the conditional distribution.
+ const MAX_ITER: u64 = 2000;   // Number of fitting iterations.
+ const NO_DIMS: usize = 2;     // Dimensionality of the embedded space.
 
-// Loads data the from a csv file skipping the first row,
-// treating it as headers and skipping the 5th column,
-// treating it as a class label.
-let mut data: Vec<f32> = bhtsne::load_csv("data.csv", true, Some(4));
-// This is the vector for the resulting embedding.
-let mut y: Vec<f32> = vec![0.0; n * no_dims];
-// Runs t-SNE.
-bhtsne::run(
-    &mut data, n, d, &mut y, no_dims, perplexity, theta, false, max_iter, 250, 250,
-);
-// Writes the embedding to a csv file.
-bhtsne::write_csv("embedding.csv", y, no_dims);
+ // Loads the data from a csv file skipping the first row,
+ // treating it as headers and skipping the 5th column,
+ // treating it as a class label.
+ // Do note that you can also use f64s.
+ let mut data: Vec<f32> = bhtsne::load_csv("iris.csv", true, Some(4));
+
+ // The vector where the bi-dimensional embedding
+ // will be stored.
+ let mut y: Vec<f32> = vec![0.0; N * NO_DIMS];
+
+ // Runs t-SNE.
+ bhtsne::run(
+     &mut data, N, D, &mut y, NO_DIMS, PERPLEXITY, THETA, false, MAX_ITER, 250, 250,
+ );
+
+ // Writes the embedding to a csv file.
+ bhtsne::write_csv("iris_embedding.csv", y, NO_DIMS);
 ```
-Also check the docs available on [crates.io](https://crates.io/crates/bhtsne).
+
 
 ## MNIST embedding
 The following embedding has been obtained by preprocessing the MNIST dataset using PCA to reduce its 

--- a/README.md
+++ b/README.md
@@ -1,8 +1,13 @@
-# bhtsne
+<div align="center"> <h1 align="center"> bhtsne </h1> </div>
+
+<div align="center">
 
 [![License: MIT](https://img.shields.io/badge/License-MIT-yellow.svg)](https://opensource.org/licenses/MIT)
 [![Gethseman](https://circleci.com/gh/frjnn/bhtsne.svg?style=shield)](https://app.circleci.com/pipelines/github/frjnn/bhtsne)
 [![codecov](https://codecov.io/gh/frjnn/bhtsne/branch/master/graph/badge.svg)](https://codecov.io/gh/frjnn/bhtsne)
+
+</div>
+
 
 Barnes-Hut implementation of t-SNE written in Rust. The algorithm is described with fine detail in [this paper](http://lvdmaaten.github.io/publications/papers/JMLR_2014.pdf) by Laurens van der Maaten.
 

--- a/src/tsne/mod.rs
+++ b/src/tsne/mod.rs
@@ -357,7 +357,15 @@ pub fn compute_gaussian_perplexity<T>(
                 } else {
                     max_beta = beta;
                     if min_beta == T::max_value() || min_beta == -T::max_value() {
-                        beta /= T::from(2.0).unwrap();
+                        if beta < T::zero() {
+                            beta *= T::from(2.).unwrap();
+                        } else {
+                            if beta <= T::one() {
+                                beta = T::from(-0.5).unwrap()
+                            } else {
+                                beta /= T::from(2.0).unwrap();
+                            }
+                        }
                     } else {
                         beta = (beta + min_beta) / T::from(2.0).unwrap();
                     }

--- a/src/tsne/mod.rs
+++ b/src/tsne/mod.rs
@@ -304,7 +304,7 @@ pub fn compute_gaussian_perplexity<T>(
     // Build ball tree on data set.
     let mut items: Vec<DataPoint<&[T]>> = Vec::new();
     for (index, chunk) in x.chunks_exact(d).enumerate() {
-        items.push(DataPoint::new(index as u64, chunk, d));
+        items.push(DataPoint::new(index as u64, chunk));
     }
     let mut slice_of_ref: Vec<&DataPoint<&[T]>> = items.iter().collect::<Vec<&DataPoint<&[T]>>>();
     let mut tree: VPTree<T> = VPTree::new(&mut slice_of_ref);

--- a/src/tsne/sptree.rs
+++ b/src/tsne/sptree.rs
@@ -190,69 +190,68 @@ where
     /// `new_index` - index of a point.
     fn insert(&mut self, new_index: usize) -> bool {
         let mut stack: Vec<&mut SPTree<T>> = vec![self];
-
         let mut inserted: bool = false;
 
         while let Some(tree) = stack.pop() {
-            let point_bound_l: usize = new_index * tree.dimension;
-            let point_bound_r: usize = point_bound_l + tree.dimension;
-
-            // Ignore objects which do not belong in this quad tree.
-            if !tree
-                .boundary
-                .contains_point(&tree.data[point_bound_l..point_bound_r])
-            {
-                continue;
+            if inserted {
+                break;
             } else {
-                // Online update of cumulative size and center-of-mass.
-                tree.cum_size += 1;
+                let point_bound_l: usize = new_index * tree.dimension;
+                let point_bound_r: usize = point_bound_l + tree.dimension;
 
-                let mult1: T =
-                    T::from(tree.cum_size - 1).unwrap() / T::from(tree.cum_size).unwrap();
-                let mult2: T = T::one() / T::from(tree.cum_size).unwrap();
+                // Ignore objects which do not belong in this quad tree.
+                if tree
+                    .boundary
+                    .contains_point(&tree.data[point_bound_l..point_bound_r])
+                {
+                    // Online update of cumulative size and center-of-mass.
+                    tree.cum_size += 1;
 
-                for d in 0..tree.dimension {
-                    tree.center_of_mass[d] *= mult1;
-                }
-                for d in 0..tree.dimension {
-                    tree.center_of_mass[d] += mult2 * tree.data[point_bound_l..point_bound_r][d];
-                }
+                    let mult1: T =
+                        T::from(tree.cum_size - 1).unwrap() / T::from(tree.cum_size).unwrap();
+                    let mult2: T = T::one() / T::from(tree.cum_size).unwrap();
 
-                // If there is space in this quad tree and it is a leaf, add the object here.
-                if tree.is_leaf && tree.size < 1 {
-                    tree.index[0] = new_index;
-                    tree.size += 1;
-                    inserted = true;
-                    break;
-                } else {
-                    // Don't add duplicates for now (this is not very nice).
-                    let mut any_duplicate: bool = false;
-
-                    for n in 0..tree.size {
-                        let mut duplicate: bool = true;
-                        for d in 0..tree.dimension {
-                            if tree.data[point_bound_l..point_bound_r][d]
-                                != tree.data[tree.index[n] * tree.dimension
-                                    ..tree.index[n] * tree.dimension + tree.dimension][d]
-                            {
-                                duplicate = false;
-                                break;
-                            }
-                        }
-                        any_duplicate |= duplicate;
+                    for d in 0..tree.dimension {
+                        tree.center_of_mass[d] *= mult1;
+                    }
+                    for d in 0..tree.dimension {
+                        tree.center_of_mass[d] +=
+                            mult2 * tree.data[point_bound_l..point_bound_r][d];
                     }
 
-                    if any_duplicate {
+                    // If there is space in this quad tree and it is a leaf, add the object here.
+                    if tree.is_leaf && tree.size < 1 {
+                        tree.index[0] = new_index;
+                        tree.size += 1;
                         inserted = true;
-                        break;
                     } else {
-                        // Otherwise, we need to subdivide the current cell.
-                        if tree.is_leaf {
-                            tree.subdivide();
+                        // Don't add duplicates for now (this is not very nice).
+                        let mut any_duplicate: bool = false;
+
+                        for n in 0..tree.size {
+                            let mut duplicate: bool = true;
+                            for d in 0..tree.dimension {
+                                if tree.data[point_bound_l..point_bound_r][d]
+                                    != tree.data[tree.index[n] * tree.dimension
+                                        ..tree.index[n] * tree.dimension + tree.dimension][d]
+                                {
+                                    duplicate = false;
+                                    break;
+                                }
+                            }
+                            any_duplicate |= duplicate;
                         }
 
-                        // Find out where the point can be inserted.
-                        stack.extend(tree.children.iter_mut())
+                        if any_duplicate {
+                            inserted = true;
+                        } else {
+                            // Otherwise, we need to subdivide the current cell.
+                            if tree.is_leaf {
+                                tree.subdivide();
+                            }
+                            // Find out where the point can be inserted.
+                            stack.extend(tree.children.iter_mut())
+                        }
                     }
                 }
             }
@@ -360,48 +359,46 @@ where
 
         while let Some(tree) = stack.pop() {
             // Make sure that we spend no time on empty nodes or self-interactions.
-            if tree.cum_size == 0
-                || (tree.is_leaf && tree.size == 1 && tree.index[0] == point_index)
+            if tree.cum_size != 0
+                && !(tree.is_leaf && tree.size == 1 && tree.index[0] == point_index)
             {
-                continue;
-            }
+                // Compute distance between point and center-of-mass.
+                let mut distance: T = T::zero();
+                let ind: usize = point_index * tree.dimension;
 
-            // Compute distance between point and center-of-mass.
-            let mut distance: T = T::zero();
-            let ind: usize = point_index * tree.dimension;
+                for d in 0..tree.dimension {
+                    tree.buff[d] = tree.data[ind + d] - tree.center_of_mass[d];
+                }
+                for d in 0..tree.dimension {
+                    distance += tree.buff[d] * tree.buff[d];
+                }
 
-            for d in 0..tree.dimension {
-                tree.buff[d] = tree.data[ind + d] - tree.center_of_mass[d];
-            }
-            for d in 0..tree.dimension {
-                distance += tree.buff[d] * tree.buff[d];
-            }
+                // Check whether we can use this node as a summary.
+                let mut max_width: T = T::zero();
+                let mut cur_width: T;
+                for d in 0..tree.dimension {
+                    cur_width = tree.boundary.width[d];
+                    max_width = if max_width > cur_width {
+                        max_width
+                    } else {
+                        cur_width
+                    }
+                }
 
-            // Check whether we can use this node as a summary.
-            let mut max_width: T = T::zero();
-            let mut cur_width: T;
-            for d in 0..tree.dimension {
-                cur_width = tree.boundary.width[d];
-                max_width = if max_width > cur_width {
-                    max_width
+                if tree.is_leaf || max_width / distance.sqrt() < theta {
+                    // Compute and add tsne force between point and current node.
+                    distance = T::one() / (T::one() + distance);
+                    let mut mult: T = T::from(tree.cum_size).unwrap() * distance;
+                    *sum_q += mult;
+                    mult *= distance;
+
+                    for (i, el) in neg_f.iter_mut().enumerate() {
+                        *el += mult * tree.buff[i];
+                    }
                 } else {
-                    cur_width
+                    // Iteratively apply Barnes-Hut algorithm.
+                    stack.extend(tree.children.iter_mut())
                 }
-            }
-
-            if tree.is_leaf || max_width / distance.sqrt() < theta {
-                // Compute and add tsne force between point and current node.
-                distance = T::one() / (T::one() + distance);
-                let mut mult: T = T::from(tree.cum_size).unwrap() * distance;
-                *sum_q += mult;
-                mult *= distance;
-
-                for (i, el) in neg_f.iter_mut().enumerate() {
-                    *el += mult * tree.buff[i];
-                }
-            } else {
-                // Iteratively apply Barnes-Hut algorithm.
-                stack.extend(tree.children.iter_mut())
             }
         }
     }

--- a/src/tsne/vptree.rs
+++ b/src/tsne/vptree.rs
@@ -1,5 +1,4 @@
 use super::super::Float;
-use pdqselect::select_by;
 use rand::Rng;
 use std::cmp::Ordering;
 use std::collections::BinaryHeap;
@@ -13,7 +12,7 @@ where
     fn metric(a: &Self, b: &Self) -> T;
 }
 
-/// The datapoint struct.
+/// Datapoint struct.
 #[derive(Clone)]
 pub struct DataPoint<T> {
     pub ind: u64,
@@ -45,11 +44,7 @@ where
 {
     /// A simple constructor.
     pub fn new(ind: u64, content: &'a [T], dims: usize) -> Self {
-        DataPoint {
-            ind,
-            content,
-            dims,
-        }
+        DataPoint { ind, content, dims }
     }
 
     /// Implements a comparison between `self` and two other `DataPoints`.
@@ -126,6 +121,26 @@ where
     }
 }
 
+/// Auxiliary struct used to build the vantage point tree.
+struct VPTreeBuilder<'a, T> {
+    root: &'a mut Option<Box<Node<T>>>,
+    lower: usize,
+    upper: usize,
+}
+
+impl<'a, T> VPTreeBuilder<'a, T> {
+    /// VPTreeBuilder constructor.
+    ///
+    /// # Arguments
+    ///
+    /// * `node` - current node.
+    /// * `lower` - lower bound.
+    /// * `upper` - upper bound.
+    fn new(root: &'a mut Option<Box<Node<T>>>, lower: usize, upper: usize) -> Self {
+        Self { root, lower, upper }
+    }
+}
+
 /// Vantage Point tree.
 pub struct VPTree<'a, T> {
     items: &'a mut [&'a DataPoint<&'a [T]>],
@@ -138,45 +153,53 @@ where
     T: Float,
     DataPoint<&'a [T]>: Measurable<T>,
 {
-    /// Function that recursively fills the tree.
+    /// Function that iteratively fills the tree.
+    ///
+    /// # Arguments
+    ///
+    /// * `root` - root of the vantage point tree.
+    /// * `items` - items to build the tree with.
+    /// * `lower' - lower bound.
+    /// * `upper` - upper bound.
     fn build_from_points(
         root: &mut Option<Box<Node<T>>>,
         items: &mut [&DataPoint<&'a [T]>],
         lower: usize,
         upper: usize,
     ) {
-        if upper == lower {
-            // Indicates that we're done here!
-            *root = None;
-            return;
+        let mut stack: Vec<VPTreeBuilder<T>> = vec![VPTreeBuilder::new(root, lower, upper)];
+
+        while let Some(builder) = stack.pop() {
+            let VPTreeBuilder { root, lower, upper } = builder;
+
+            // Lower index is center of current node.
+            if upper != lower {
+                *root = Some(Box::new(Node::new()));
+                let mut node = root.as_deref_mut().unwrap();
+                node.index = lower;
+
+                if upper - lower > 1 {
+                    // If we did not arrive at leaf yet choose an arbitrary point
+                    // and move it to the start.
+                    let i: usize = rand::thread_rng().gen_range(lower..upper) as usize;
+                    items.swap(lower, i);
+
+                    let to_cmp = items[lower];
+                    let mut c = |&a: &&DataPoint<&'a [T]>, &b: &&DataPoint<&'a [T]>| -> Ordering {
+                        to_cmp.compare(a, b)
+                    };
+                    // Partition around the median distance.
+                    let median: usize = (upper + lower) / 2;
+                    pdqselect::select_by(&mut items[lower + 1..upper], median, &mut c);
+
+                    // Threshold of the new node will be the distance to the median.
+                    node.threshold = DataPoint::<&[T]>::metric(&items[lower], &items[median]);
+
+                    stack.push(VPTreeBuilder::new(&mut node.left, lower + 1, median));
+                    stack.push(VPTreeBuilder::new(&mut node.right, median, upper));
+                }
+            }
         }
-        // Lower index is center of current node.
-        let mut node: Node<T> = Node::new();
-        node.index = lower;
-
-        if upper - lower > 1 {
-            // If we did not arrive at leaf yet choose an arbitrary point
-            // and move it to the start.
-            let i: usize = rand::thread_rng().gen_range(lower..upper) as usize;
-            items.swap(lower, i);
-
-            // Partition around the median distance.
-            let median: usize = (upper + lower) / 2;
-
-            let to_cmp = items[lower];
-            let mut c = |&a: &&DataPoint<&'a [T]>, &b: &&DataPoint<&'a [T]>| -> Ordering {
-                to_cmp.compare(a, b)
-            };
-            select_by(&mut items[lower + 1..upper], median, &mut c);
-
-            // Threshold of the new node will be the distance to the median.
-            node.threshold = DataPoint::<&[T]>::metric(&items[lower], &items[median]);
-            // Recursively build tree.
-            node.index = lower;
-            VPTree::build_from_points(&mut node.left, items, lower + 1, median);
-            VPTree::build_from_points(&mut node.right, items, median, upper);
-        }
-        *root = Some(Box::new(node));
     }
 
     /// Auxiliary function that searches for the k nearest neighbors of an item.
@@ -188,61 +211,65 @@ where
         k: usize,
         heap: &mut BinaryHeap<HeapItem<T>>,
     ) {
-        // Indicates that we're done here!
-        let node: &Node<T> = match node {
-            Some(_node) => _node.as_ref(),
-            None => return,
-        };
+        let mut stack: Vec<&Option<Box<Node<T>>>> = vec![node];
 
-        // Compute distance between target and current node.
-        let dist: T = DataPoint::<&'a [T]>::metric(items[node.index], target);
-        if dist < *tau {
-            // If current node is within the radius tau
-            // remove furthest node from result list (if we already have k results),
-            // add current node to result list and
-            // update value of tau (farthest point in result list).
-            if heap.len() == k {
-                heap.pop();
-            }
-            heap.push(HeapItem {
-                index: node.index,
-                dist,
-            });
-            if heap.len() == k {
-                *tau = heap.peek().unwrap().dist;
-            }
-        }
+        while let Some(_node) = stack.pop() {
+            if let Some(ref node) = _node {
+                // Compute distance between target and current node.
+                let dist: T = DataPoint::<&'a [T]>::metric(items[node.index], target);
+                if dist < *tau {
+                    // If current node is within the radius tau
+                    // remove furthest node from result list (if we already have k results),
+                    // add current node to result list and
+                    // update value of tau (farthest point in result list).
+                    if heap.len() == k {
+                        heap.pop();
+                    }
+                    heap.push(HeapItem {
+                        index: node.index,
+                        dist,
+                    });
+                    if heap.len() == k {
+                        *tau = heap.peek().unwrap().dist;
+                    }
+                }
 
-        match (node.left.as_ref(), node.right.as_ref()) {
-            // Return if we arrived at a leaf.
-            (None, None) => (),
-            (_, _) => {
-                // If the target lies within the radius of ball.
-                if dist < node.threshold {
-                    // if there can still be neighbors inside the ball, recursively search left child first.
-                    if dist - *tau <= node.threshold {
-                        VPTree::_search(items, tau, &node.left, target, k, heap)
-                    }
-                    // if there can still be neighbors outside the ball, recursively search right child.
-                    if dist + *tau >= node.threshold {
-                        VPTree::_search(items, tau, &node.right, target, k, heap)
-                    }
-                } else {
-                    // If the target lies outsize the radius of the ball.
-                    // If there can still be neighbors outside the ball, recursively search right child.
-                    if dist + *tau >= node.threshold {
-                        VPTree::_search(items, tau, &node.right, target, k, heap)
-                    }
-                    // if there can still be neighbors inside the ball, recursively search left child.
-                    if dist - *tau <= node.threshold {
-                        VPTree::_search(items, tau, &node.left, target, k, heap)
+                match (node.left.as_ref(), node.right.as_ref()) {
+                    // Return if we arrived at a leaf.
+                    (None, None) => continue,
+                    (_, _) => {
+                        // If the target lies within the radius of ball.
+                        if dist < node.threshold {
+                            // if there can still be neighbors inside the ball, recursively search left child first.
+                            if dist - *tau <= node.threshold {
+                                stack.push(&node.left)
+                            }
+                            // if there can still be neighbors outside the ball, recursively search right child.
+                            if dist + *tau >= node.threshold {
+                                stack.push(&node.right)
+                            }
+                        } else {
+                            // If the target lies outsize the radius of the ball.
+                            // If there can still be neighbors outside the ball, recursively search right child.
+                            if dist + *tau >= node.threshold {
+                                stack.push(&node.right)
+                            }
+                            // if there can still be neighbors inside the ball, recursively search left child.
+                            if dist - *tau <= node.threshold {
+                                stack.push(&node.left)
+                            }
+                        }
                     }
                 }
             }
         }
     }
 
-    /// Default constructor for the `VPTree` struct.
+    /// Constructor for the `VPTree` struct.
+    ///
+    /// # Arguments
+    ///
+    /// `items` - items to build the tree with.
     pub fn new(items: &'a mut [&'a DataPoint<&'a [T]>]) -> Self
     where
         T: Float,
@@ -258,7 +285,14 @@ where
         tree
     }
 
-    /// Function that uses the tree to find the k nearest neighbors of `target`.
+    /// Function that searches the tree and finds the k nearest neighbors of `target`.
+    ///
+    /// # Arguments
+    ///
+    /// * `target` -  target data point.
+    /// * `k` - number of nearest neighbors.
+    /// * `results` - vector in which the index of the nearest neighbors will be saved.
+    /// * `distances` - vector storing relative distances of the nearest neighbors.
     pub fn search(
         &mut self,
         target: &DataPoint<&'a [T]>,
@@ -272,14 +306,7 @@ where
         self.tau = T::max_value();
 
         // Perform the search.
-        VPTree::_search(
-            &self.items,
-            &mut self.tau,
-            &self.root,
-            target,
-            k,
-            &mut heap,
-        );
+        VPTree::_search(&self.items, &mut self.tau, &self.root, target, k, &mut heap);
 
         // Empties the important vectors.
         results.clear();

--- a/src/tsne/vptree.rs
+++ b/src/tsne/vptree.rs
@@ -13,11 +13,9 @@ where
 }
 
 /// Datapoint struct.
-#[derive(Clone)]
 pub struct DataPoint<T> {
     pub ind: u64,
     content: T,
-    dims: usize,
 }
 
 impl<'a, T> Measurable<T> for DataPoint<&[T]>
@@ -43,8 +41,8 @@ where
     Self: Measurable<T>,
 {
     /// A simple constructor.
-    pub fn new(ind: u64, content: &'a [T], dims: usize) -> Self {
-        DataPoint { ind, content, dims }
+    pub fn new(ind: u64, content: &'a [T]) -> Self {
+        DataPoint { ind, content }
     }
 
     /// Implements a comparison between `self` and two other `DataPoints`.
@@ -168,6 +166,7 @@ where
         upper: usize,
     ) {
         let mut stack: Vec<VPTreeBuilder<T>> = vec![VPTreeBuilder::new(root, lower, upper)];
+        let mut thread_rng = rand::thread_rng();
 
         while let Some(builder) = stack.pop() {
             let VPTreeBuilder { root, lower, upper } = builder;
@@ -181,7 +180,7 @@ where
                 if upper - lower > 1 {
                     // If we did not arrive at leaf yet choose an arbitrary point
                     // and move it to the start.
-                    let i: usize = rand::thread_rng().gen_range(lower..upper) as usize;
+                    let i: usize = thread_rng.gen_range(lower..upper) as usize;
                     items.swap(lower, i);
 
                     let to_cmp = items[lower];
@@ -312,8 +311,7 @@ where
         results.clear();
         distances.clear();
         // Gather final results.
-        while !heap.is_empty() {
-            let el: HeapItem<T> = heap.pop().unwrap();
+        while let Some(el) = heap.pop() {
             results.push(self.items[el.index].ind);
             distances.push(el.dist);
         }


### PR DESCRIPTION
The performance of this implementation is slightly better when the construction and the search though the VPTree is done in an iterative manner. However, by implementing the SPTree too in an iterative way the performance worsen noticeably.