### PR TITLE
Replace pdqselect with select_nth_unstable_by

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -19,7 +19,6 @@ default = ["csv"]
 rand = "0.8.4"
 rand_distr = "0.4.2"
 rayon = "1.5.1"
-pdqselect = "0.1.0"
 num-traits = "0.2.14"
 csv = {version = "1.1.6", optional = true}
 

--- a/src/tsne/vptree.rs
+++ b/src/tsne/vptree.rs
@@ -137,8 +137,7 @@ impl<'a, T: Float + Debug + Display + Send + Sync, U> VPTree<'a, T, U> {
                     let (_, to_cmp) = self.items[lower];
                     // Partition around the median distances.
                     let median: usize = (upper + lower) / 2;
-                    pdqselect::select_by(
-                        &mut self.items[lower + 1..upper],
+                    self.items[lower + 1..upper].select_nth_unstable_by(
                         median,
                         &mut |a: &(usize, &U), b: &(usize, &U)| {
                             if metric_f(to_cmp, a.1) < metric_f(to_cmp, b.1) {

--- a/src/tsne/vptree.rs
+++ b/src/tsne/vptree.rs
@@ -138,7 +138,7 @@ impl<'a, T: Float + Debug + Display + Send + Sync, U> VPTree<'a, T, U> {
                     // Partition around the median distances.
                     let median: usize = (upper + lower) / 2;
                     self.items[lower + 1..upper].select_nth_unstable_by(
-                        median,
+                        median - lower - 1,
                         &mut |a: &(usize, &U), b: &(usize, &U)| {
                             if metric_f(to_cmp, a.1) < metric_f(to_cmp, b.1) {
                                 Ordering::Less


### PR DESCRIPTION
Switch from `pdqselect` dependency to official version of the algorithm. Issue with `pdqselect` is that the 0.1.1 version broke all older compilers by updating to the 2021 edition.