### PR TITLE
Add a method for getting the output directly

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -700,6 +700,14 @@ where
         // Everything went smooth.
         Ok(self)
     }
+
+    /// retrieve the computed embedding directly
+    pub fn get_embedding(&self) -> Vec<T> {
+        self.y
+            .iter()
+            .map(|x| x.0)
+            .collect()
+    }
 }
 
 /// Loads data from a csv file.


### PR DESCRIPTION
This PR adds a simple method for retrieving the results, without writing them to a csv-file. This seems to obvious to be an oversight, so maybe there's some conscious design reason for why it's not in there? Nevertheless, I figured I might as well send a PR rather than just file an issue.

Thank you for this crate!