### PR TITLE
fix: Index out of bounds in symmetrize_spare_matrix

### DIFF
--- a/src/tsne/mod.rs
+++ b/src/tsne/mod.rs
@@ -295,7 +295,7 @@ pub(super) fn symmetrize_sparse_matrix<T>(
     for _n in 0..n_samples {
         for i in p_rows(_n)..p_rows(_n + 1) {
             row_counts[_n] += 1;
-            if p_columns[p_rows(p_columns[i].0)..p_rows(p_columns[i].0 + 1)]
+            if !p_columns[p_rows(p_columns[i].0)..p_rows(p_columns[i].0 + 1)]
                 .iter()
                 .any(|el| el.0 == _n)
             {


### PR DESCRIPTION
Received this error intermittently:

```
thread 'main' panicked at 'index out of bounds: the len is 3173830 but the index is 3173830', /home/ehernva/.cargo/git/checkouts/bhtsne-5d23f839d3bdde38/69c58bf/src/tsne/mod.rs:347:17
stack backtrace:
0: rust_begin_unwind at /rustc/02072b482a8b5357f7fb5e5637444ae30e423c40/library/std/src/panicking.rs:498:5
1: core::panicking::panic_fmt at /rustc/02072b482a8b5357f7fb5e5637444ae30e423c40/library/core/src/panicking.rs:107:14
2: core::panicking::panic_bounds_check at /rustc/02072b482a8b5357f7fb5e5637444ae30e423c40/library/core/src/panicking.rs:75:5
3: bhtsne::tsne::symmetrize_sparse_matrix
4: bhtsne::tSNE<T,U>::barnes_hut
5: embed::main
```

I don't have an indepth understanding of this code, but it seems to me like the condition in the loop that calculates the number of columns per row is the opposite of the one that is used to increase the offsets in the main loop. From my testing, this seems to solve the problem, but probably worth thinking through that it's a valid fix before accepting this PR.