### PR TITLE
Add wasm support

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -6,9 +6,7 @@ jobs:
   build:
     machine: true
     steps:
-      - run:
-          name: Checkout repository
-          command: git clone https://github.com/frjnn/bhtsne.git .
+      - checkout
       - run:
           name: Download iris dataset
           command: curl -O "https://gist.githubusercontent.com/curran/a08a1080b88344b0c8a7/raw/0e7a9b0a5d22642a06d3d5b9bcbad9890c8ee534/iris.csv"
@@ -23,3 +21,29 @@ jobs:
             cargo tarpaulin --out Xml --all-features --ignored --timeout 600
       - codecov/upload:
           file: cobertura.xml
+  wasm:
+    docker:
+      - image: cimg/rust:1.89.0
+    steps:
+      - checkout
+      - run:
+          name: Add wasm targets
+          command: rustup target add wasm32-unknown-unknown wasm32-wasip1
+      - run:
+          name: Check wasm32-unknown-unknown with default features
+          command: cargo check --target wasm32-unknown-unknown
+      - run:
+          name: Check wasm32-unknown-unknown with the wasm_js feature
+          command: cargo check --target wasm32-unknown-unknown --features wasm_js
+      - run:
+          name: Check wasm32-wasip1
+          command: cargo check --target wasm32-wasip1
+      - run:
+          name: Clippy on wasm32-unknown-unknown
+          command: cargo clippy --target wasm32-unknown-unknown --features wasm_js -- -D warnings
+
+workflows:
+  ci:
+    jobs:
+      - build
+      - wasm

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -19,14 +19,31 @@ version = "0.5.5"
 
 [features]
 default = ["csv"]
+# On wasm32-unknown-unknown, uses the JavaScript host's crypto.getRandomValues as the
+# entropy source through the wasm_js backend of getrandom. Requires running in a
+# JavaScript environment (browser or Node.js). Without this feature the
+# wasm32-unknown-unknown build falls back to a fixed seed and produces deterministic
+# embeddings. Has no effect on other targets.
+wasm_js = ["dep:getrandom", "rand/thread_rng"]
 
 [dependencies]
 crossbeam = "0.8"
 csv = { version = "1", optional = true }
 num-traits = "0.2"
-rand = "0.9"
 rand_distr = "0.5"
 rayon = "1"
+
+# On wasm32-unknown-unknown there is no OS entropy source, getrandom refuses to compile for
+# that target unless the final binary opts into the JavaScript backend. The thread local
+# generator is therefore replaced by a deterministic small generator, see make_rng.
+[target.'cfg(not(all(target_arch = "wasm32", target_os = "unknown")))'.dependencies]
+rand = "0.9"
+
+[target.'cfg(all(target_arch = "wasm32", target_os = "unknown"))'.dependencies]
+rand = { version = "0.9", default-features = false, features = ["std", "small_rng"] }
+# Since getrandom 0.3.3 enabling the wasm_js feature is enough to select the JavaScript
+# backend on wasm32-unknown-unknown, no rustflags cfg is needed.
+getrandom = { version = "0.3.3", optional = true, features = ["wasm_js"] }
 
 [dev-dependencies]
 csv = "1.3"

--- a/src/tsne/mod.rs
+++ b/src/tsne/mod.rs
@@ -85,6 +85,36 @@ pub(super) fn clear_buffers<T: Float + Send + Sync>(
     *gains = Vec::new(); // Gains.
 }
 
+/// Returns the source of randomness used by the crate. On targets where an entropy
+/// source is available this is the thread local generator. This includes
+/// wasm32-unknown-unknown when the wasm_js feature is enabled, in which case entropy
+/// comes from the JavaScript host through getrandom. Otherwise, on
+/// wasm32-unknown-unknown no entropy source exists, so a small deterministic generator
+/// with a fixed seed is used instead.
+#[cfg(any(
+    not(all(target_arch = "wasm32", target_os = "unknown")),
+    feature = "wasm_js"
+))]
+pub(super) fn make_rng() -> impl rand::Rng {
+    rand::rng()
+}
+
+/// Returns the source of randomness used by the crate. On targets where an entropy
+/// source is available this is the thread local generator. This includes
+/// wasm32-unknown-unknown when the wasm_js feature is enabled, in which case entropy
+/// comes from the JavaScript host through getrandom. Otherwise, on
+/// wasm32-unknown-unknown no entropy source exists, so a small deterministic generator
+/// with a fixed seed is used instead.
+#[cfg(all(
+    target_arch = "wasm32",
+    target_os = "unknown",
+    not(feature = "wasm_js")
+))]
+pub(super) fn make_rng() -> impl rand::Rng {
+    use rand::SeedableRng;
+    rand::rngs::SmallRng::seed_from_u64(0x6268_7473_6e65)
+}
+
 /// Random initializes the embedding sampling from a normal distribution with mean 0 and sigma 1e-4.
 ///
 /// # Arguments
@@ -92,7 +122,7 @@ pub(super) fn clear_buffers<T: Float + Send + Sync>(
 /// `y` - embedding.
 pub(super) fn random_init<T: Float + Send + Sync + Copy>(y: &mut [CachePadded<T>]) {
     let distr = Normal::new(0.0, 1e-4).unwrap();
-    let mut rng = rand::rng();
+    let mut rng = make_rng();
     y.iter_mut()
         .for_each(|el| **el = T::from(distr.sample(&mut rng)).unwrap());
 }

--- a/src/tsne/vptree.rs
+++ b/src/tsne/vptree.rs
@@ -121,7 +121,7 @@ impl<'a, T: Float + Send + Sync, U> VPTree<'a, T, U> {
         F: Fn(&U, &U) -> T,
     {
         let mut stack = vec![VPTreeBuilder::new(&mut self.root, lower, upper)];
-        let mut thread_rng = rand::rng();
+        let mut thread_rng = super::make_rng();
 
         while let Some(builder) = stack.pop() {
             let VPTreeBuilder { root, lower, upper } = builder;


### PR DESCRIPTION
Makes the crate compile on wasm32 targets. On wasm32-unknown-unknown, rand is built without getrandom and falls back to a fixed seed SmallRng, while the new opt-in `wasm_js` feature restores real entropy in JavaScript hosts. CI now checks the wasm targets.