### PR TITLE
Add per-epoch callback for observing fitting progress

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -76,6 +76,13 @@ use rayon::{
     slice::{ParallelSlice, ParallelSliceMut},
 };
 
+/// Boxed closure invoked at the end of each fitting epoch with the epoch index and a
+/// snapshot of the current embedding. See [`tSNE::epoch_callback`].
+///
+/// The `Send + Sync` bounds only serve to keep [`tSNE`] itself `Send + Sync`, the
+/// callback is only ever invoked sequentially from the fitting thread.
+pub type EpochCallback<'data, T> = Box<dyn FnMut(usize, &[T]) + Send + Sync + 'data>;
+
 /// t-distributed stochastic neighbor embedding. Provides a parallel implementation of both the
 /// exact version of the algorithm and the tree accelerated one leveraging space partitioning trees.
 #[allow(non_camel_case_types)]
@@ -101,6 +108,7 @@ where
     dy: Vec<CachePadded<T>>,
     uy: Vec<CachePadded<T>>,
     gains: Vec<CachePadded<T>>,
+    epoch_callback: Option<EpochCallback<'data, T>>,
 }
 
 impl<'data, T, U> tSNE<'data, T, U>
@@ -183,6 +191,7 @@ where
             dy: Vec::new(),
             uy: Vec::new(),
             gains: Vec::new(),
+            epoch_callback: None,
         }
     }
 
@@ -281,6 +290,54 @@ where
         self
     }
 
+    /// Sets a callback invoked at the end of each fitting epoch by both [`exact`]
+    /// and [`barnes_hut`].
+    ///
+    /// # Arguments
+    ///
+    /// `callback` - closure called with the zero-based epoch index and a snapshot of
+    /// the current embedding, laid out as in the result of [`embedding`]. It can be
+    /// used to monitor convergence or to animate intermediate embeddings.
+    ///
+    /// The callback is invoked sequentially from the calling thread once per epoch.
+    /// To observe progress more sparsely simply return early from the closure for
+    /// the epochs to skip.
+    ///
+    /// The `Send + Sync` bounds only serve to keep [`tSNE`] itself `Send + Sync`.
+    /// On single threaded targets, such as wasm, closures over non `Send` resources
+    /// can be made compatible with a wrapper like the `send_wrapper` crate.
+    ///
+    /// [`exact`]: tSNE::exact
+    /// [`barnes_hut`]: tSNE::barnes_hut
+    /// [`embedding`]: tSNE::embedding
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use bhtsne::tSNE;
+    ///
+    /// const N: usize = 100;
+    /// const D: usize = 25;
+    ///
+    /// let data: Vec<f32> = vec![0.0_f32; N * D];
+    /// let vectors: Vec<&[f32]> = data.chunks(D).collect();
+    ///
+    /// let mut tsne: tSNE<f32, &[f32]> = tSNE::new(&vectors);
+    /// tsne.epoch_callback(|epoch, embedding| {
+    ///     if epoch % 10 == 0 {
+    ///         println!("epoch {}: {} coordinates", epoch, embedding.len());
+    ///     }
+    /// });
+    /// ```
+    pub fn epoch_callback<C>(&mut self, callback: C) -> &mut Self
+    where
+        C: FnMut(usize, &[T]) + Send + Sync + 'data,
+    {
+        self.epoch_callback = Some(Box::new(callback));
+
+        self
+    }
+
     /// Returns the computed embedding.
     pub fn embedding(&self) -> Vec<T> {
         self.y.iter().map(|x| **x).collect()
@@ -373,6 +430,15 @@ where
         // to make the solution zero mean.
         let mut means: Vec<T> = vec![T::zero(); embedding_dim];
 
+        // The callback is moved out of self so that the epoch loop is free to borrow
+        // the other fields mutably. It is put back at the end of the fitting.
+        let mut epoch_callback = self.epoch_callback.take();
+        // Scratch buffer for the embedding snapshots passed to the callback.
+        let mut snapshot: Vec<T> = match epoch_callback {
+            Some(_) => vec![T::zero(); grad_entries],
+            None => Vec::new(),
+        };
+
         // Main fitting loop.
         for epoch in 0..self.epochs {
             // Compute pairwise squared euclidean distances between embeddings in parallel.
@@ -449,7 +515,18 @@ where
             if epoch == self.momentum_switch_epoch {
                 self.momentum = self.final_momentum;
             }
+
+            // Reports the embedding at the end of the epoch.
+            if let Some(callback) = epoch_callback.as_mut() {
+                snapshot
+                    .iter_mut()
+                    .zip(self.y.iter())
+                    .for_each(|(dst, src)| *dst = **src);
+                callback(epoch, &snapshot);
+            }
         }
+        // Puts the callback back in place.
+        self.epoch_callback = epoch_callback;
         // Clears buffers used for fitting.
         tsne::clear_buffers(&mut self.dy, &mut self.uy, &mut self.gains);
 
@@ -576,6 +653,15 @@ where
         // to make the solution zero mean.
         let mut means: Vec<T> = vec![T::zero(); embedding_dim];
 
+        // The callback is moved out of self so that the epoch loop is free to borrow
+        // the other fields mutably. It is put back at the end of the fitting.
+        let mut epoch_callback = self.epoch_callback.take();
+        // Scratch buffer for the embedding snapshots passed to the callback.
+        let mut snapshot: Vec<T> = match epoch_callback {
+            Some(_) => vec![T::zero(); grad_entries],
+            None => Vec::new(),
+        };
+
         // Main Training loop.
         for epoch in 0..self.epochs {
             {
@@ -663,7 +749,18 @@ where
             if epoch == self.momentum_switch_epoch {
                 self.momentum = self.final_momentum;
             }
+
+            // Reports the embedding at the end of the epoch.
+            if let Some(callback) = epoch_callback.as_mut() {
+                snapshot
+                    .iter_mut()
+                    .zip(self.y.iter())
+                    .for_each(|(dst, src)| *dst = **src);
+                callback(epoch, &snapshot);
+            }
         }
+        // Puts the callback back in place.
+        self.epoch_callback = epoch_callback;
         // Clears buffers used for fitting.
         tsne::clear_buffers(&mut self.dy, &mut self.uy, &mut self.gains);
 

--- a/src/test.rs
+++ b/src/test.rs
@@ -65,6 +65,13 @@ fn set_perplexity() {
 }
 
 #[test]
+fn set_epoch_callback() {
+    let mut tsne: tSNE<f32, f32> = tSNE::new(&[0.]);
+    tsne.epoch_callback(|_epoch, _embedding| {});
+    assert!(tsne.epoch_callback.is_some());
+}
+
+#[test]
 #[ignore = "requires iris dataset"]
 fn exact_tsne() {
     let data: Vec<f32> =
@@ -137,6 +144,106 @@ fn barnes_hut_tsne() {
             THETA
         ) < 5.0
     );
+}
+
+/// The epoch callback must be invoked once per epoch, in order, with a snapshot
+/// of the embedding whose final value matches the result of `embedding`, and it
+/// must survive the fitting so that subsequent runs can reuse it.
+#[test]
+fn epoch_callback_reports_each_barnes_hut_epoch() {
+    const N: usize = 60;
+    const DIM: usize = 4;
+    const RUN_EPOCHS: usize = 100;
+
+    // Deterministic LCG so the test needs no RNG dependency.
+    let mut state = 7_u64;
+    let mut next = move || {
+        state = state
+            .wrapping_mul(6364136223846793005)
+            .wrapping_add(1442695040888963407);
+        ((state >> 33) as f32 / u32::MAX as f32) - 0.5
+    };
+    let data: Vec<f32> = (0..N * DIM).map(|_| next()).collect();
+    let samples: Vec<&[f32]> = data.chunks(DIM).collect();
+
+    let mut epochs_seen: Vec<usize> = Vec::new();
+    let mut last_snapshot: Vec<f32> = Vec::new();
+
+    let embedding = {
+        let mut tsne = tSNE::new(&samples);
+        tsne.embedding_dim(NO_DIMS)
+            .perplexity(PERPLEXITY)
+            .epochs(RUN_EPOCHS)
+            .epoch_callback(|epoch, snapshot| {
+                assert_eq!(snapshot.len(), N * NO_DIMS as usize);
+                epochs_seen.push(epoch);
+                last_snapshot.clear();
+                last_snapshot.extend_from_slice(snapshot);
+            })
+            .barnes_hut(THETA, |sample_a, sample_b| {
+                sample_a
+                    .iter()
+                    .zip(sample_b.iter())
+                    .map(|(a, b)| (a - b).powi(2))
+                    .sum::<f32>()
+                    .sqrt()
+            });
+        // The callback must be put back in place once the fitting is over.
+        assert!(tsne.epoch_callback.is_some());
+        tsne.embedding()
+    };
+
+    assert_eq!(epochs_seen, (0..RUN_EPOCHS).collect::<Vec<usize>>());
+    assert_eq!(last_snapshot, embedding);
+}
+
+/// Same as `epoch_callback_reports_each_barnes_hut_epoch` for the exact version
+/// of the algorithm.
+#[test]
+fn epoch_callback_reports_each_exact_epoch() {
+    const N: usize = 60;
+    const DIM: usize = 4;
+    const RUN_EPOCHS: usize = 50;
+
+    // Deterministic LCG so the test needs no RNG dependency.
+    let mut state = 7_u64;
+    let mut next = move || {
+        state = state
+            .wrapping_mul(6364136223846793005)
+            .wrapping_add(1442695040888963407);
+        ((state >> 33) as f32 / u32::MAX as f32) - 0.5
+    };
+    let data: Vec<f32> = (0..N * DIM).map(|_| next()).collect();
+    let samples: Vec<&[f32]> = data.chunks(DIM).collect();
+
+    let mut epochs_seen: Vec<usize> = Vec::new();
+    let mut last_snapshot: Vec<f32> = Vec::new();
+
+    let embedding = {
+        let mut tsne = tSNE::new(&samples);
+        tsne.embedding_dim(NO_DIMS)
+            .perplexity(PERPLEXITY)
+            .epochs(RUN_EPOCHS)
+            .epoch_callback(|epoch, snapshot| {
+                assert_eq!(snapshot.len(), N * NO_DIMS as usize);
+                epochs_seen.push(epoch);
+                last_snapshot.clear();
+                last_snapshot.extend_from_slice(snapshot);
+            })
+            .exact(|sample_a, sample_b| {
+                sample_a
+                    .iter()
+                    .zip(sample_b.iter())
+                    .map(|(a, b)| (a - b).powi(2))
+                    .sum()
+            });
+        // The callback must be put back in place once the fitting is over.
+        assert!(tsne.epoch_callback.is_some());
+        tsne.embedding()
+    };
+
+    assert_eq!(epochs_seen, (0..RUN_EPOCHS).collect::<Vec<usize>>());
+    assert_eq!(last_snapshot, embedding);
 }
 
 /// Regression test for the Gaussian bandwidth binary search.


### PR DESCRIPTION
Adds an optional epoch_callback builder method that receives the epoch number and a snapshot of the current embedding at the end of each gradient descent epoch. This makes it possible to stream intermediate embeddings out of a long run, for example to animate the layout in a UI or to log convergence. The callback is stored as a boxed closure on the builder, costs nothing when unset, and the snapshot is copied into a reusable scratch buffer so the embedding itself is never aliased. Covered by tests for both the exact and Barnes-Hut paths, plus a doctest on the builder method.