### PR TITLE
Forbid unsafe code crate-wide

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -26,6 +26,9 @@ default = ["csv"]
 # embeddings. Has no effect on other targets.
 wasm_js = ["dep:getrandom", "rand/thread_rng"]
 
+[lints.rust]
+unsafe_code = "forbid"
+
 [dependencies]
 crossbeam = "0.8"
 csv = { version = "1", optional = true }


### PR DESCRIPTION
The crate is entirely safe Rust today. This adds unsafe_code = "forbid" to the Cargo.toml [lints.rust] table so it stays that way: any unsafe block added later becomes a compile error. forbid rather than deny so it cannot be silenced with a local allow.