### PR TITLE
Expose the embedding KL divergence as a public method

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -83,6 +83,13 @@ use rayon::{
 /// callback is only ever invoked sequentially from the fitting thread.
 pub type EpochCallback<'data, T> = Box<dyn FnMut(usize, &[T]) + Send + Sync + 'data>;
 
+/// Records which fitting routine last ran, so [`tSNE::kl_divergence`] can pick
+/// the matching cost evaluation.
+enum Fit<T> {
+    Exact,
+    BarnesHut { theta: T },
+}
+
 /// t-distributed stochastic neighbor embedding. Provides a parallel implementation of both the
 /// exact version of the algorithm and the tree accelerated one leveraging space partitioning trees.
 #[allow(non_camel_case_types)]
@@ -110,6 +117,7 @@ where
     gains: Vec<CachePadded<T>>,
     epoch_callback: Option<EpochCallback<'data, T>>,
     initial_embedding: Option<Vec<T>>,
+    fit: Option<Fit<T>>,
 }
 
 impl<'data, T, U> tSNE<'data, T, U>
@@ -194,6 +202,7 @@ where
             gains: Vec::new(),
             epoch_callback: None,
             initial_embedding: None,
+            fit: None,
         }
     }
 
@@ -359,6 +368,34 @@ where
     /// Returns the computed embedding.
     pub fn embedding(&self) -> Vec<T> {
         self.y.iter().map(|x| **x).collect()
+    }
+
+    /// Returns the Kullback-Leibler divergence of the current embedding, the cost
+    /// t-SNE minimizes, or `None` before a fit. Exact after [`exact`], a tree
+    /// approximation after [`barnes_hut`]. Recomputed on each call.
+    ///
+    /// [`exact`]: tSNE::exact
+    /// [`barnes_hut`]: tSNE::barnes_hut
+    pub fn kl_divergence(&self) -> Option<T> {
+        let n_samples = self.data.len();
+        let embedding_dim = self.embedding_dim as usize;
+        match self.fit.as_ref()? {
+            Fit::Exact => Some(tsne::evaluate_error(
+                &self.p_values,
+                &self.y,
+                n_samples,
+                embedding_dim,
+            )),
+            Fit::BarnesHut { theta } => Some(tsne::evaluate_error_approximately(
+                &self.p_rows,
+                &self.p_columns,
+                &self.p_values,
+                &self.y,
+                n_samples,
+                embedding_dim,
+                *theta,
+            )),
+        }
     }
 
     /// Performs a parallel exact version of the t-SNE algorithm. Pairwise distances between samples
@@ -564,6 +601,7 @@ where
         self.epoch_callback = epoch_callback;
         // Clears buffers used for fitting.
         tsne::clear_buffers(&mut self.dy, &mut self.uy, &mut self.gains);
+        self.fit = Some(Fit::Exact);
 
         self
     }
@@ -815,6 +853,7 @@ where
         self.epoch_callback = epoch_callback;
         // Clears buffers used for fitting.
         tsne::clear_buffers(&mut self.dy, &mut self.uy, &mut self.gains);
+        self.fit = Some(Fit::BarnesHut { theta });
 
         self
     }

--- a/src/test.rs
+++ b/src/test.rs
@@ -79,6 +79,54 @@ fn set_initial_embedding() {
 }
 
 #[test]
+fn kl_divergence_is_none_before_fitting() {
+    let data = [0.0_f32, 1.0, 2.0, 3.0];
+    let samples: Vec<&[f32]> = data.chunks(1).collect();
+    let tsne: tSNE<f32, &[f32]> = tSNE::new(&samples);
+    assert!(tsne.kl_divergence().is_none());
+}
+
+#[test]
+fn kl_divergence_after_barnes_hut_is_finite_and_nonnegative() {
+    const N: usize = 60;
+    const DIM: usize = 4;
+    let data = lcg_samples(N, DIM, 7);
+    let samples: Vec<&[f32]> = data.chunks(DIM).collect();
+
+    let mut tsne = tSNE::new(&samples);
+    tsne.embedding_dim(NO_DIMS)
+        .perplexity(PERPLEXITY)
+        .epochs(100)
+        .barnes_hut(THETA, |a, b| {
+            a.iter()
+                .zip(b.iter())
+                .map(|(x, y)| (x - y).powi(2))
+                .sum::<f32>()
+                .sqrt()
+        });
+
+    let kl = tsne.kl_divergence().expect("fitted");
+    assert!(kl.is_finite() && kl >= 0.0, "{kl}");
+}
+
+#[test]
+fn kl_divergence_after_exact_is_finite_and_nonnegative() {
+    const N: usize = 60;
+    const DIM: usize = 4;
+    let data = lcg_samples(N, DIM, 7);
+    let samples: Vec<&[f32]> = data.chunks(DIM).collect();
+
+    let mut tsne = tSNE::new(&samples);
+    tsne.embedding_dim(NO_DIMS)
+        .perplexity(PERPLEXITY)
+        .epochs(100)
+        .exact(|a, b| a.iter().zip(b.iter()).map(|(x, y)| (x - y).powi(2)).sum());
+
+    let kl = tsne.kl_divergence().expect("fitted");
+    assert!(kl.is_finite() && kl >= 0.0, "{kl}");
+}
+
+#[test]
 #[ignore = "requires iris dataset"]
 fn exact_tsne() {
     let data: Vec<f32> =
@@ -103,14 +151,7 @@ fn exact_tsne() {
 
     assert_eq!(points.len(), samples.len());
 
-    assert!(
-        tsne::evaluate_error(
-            &tsne.p_values,
-            &tsne.y,
-            samples.len(),
-            tsne.embedding_dim as usize
-        ) < 0.5
-    );
+    assert!(tsne.kl_divergence().unwrap() < 0.5);
 }
 
 #[test]
@@ -140,17 +181,7 @@ fn barnes_hut_tsne() {
 
     assert_eq!(points.len(), samples.len());
 
-    assert!(
-        tsne::evaluate_error_approximately(
-            &tsne.p_rows,
-            &tsne.p_columns,
-            &tsne.p_values,
-            &tsne.y,
-            samples.len(),
-            tsne.embedding_dim as usize,
-            THETA
-        ) < 5.0
-    );
+    assert!(tsne.kl_divergence().unwrap() < 5.0);
 }
 
 /// The epoch callback must be invoked once per epoch, in order, with a snapshot

--- a/src/tsne/mod.rs
+++ b/src/tsne/mod.rs
@@ -490,7 +490,6 @@ pub(super) fn zero_mean<T>(
 /// * `n_samples` - number of samples in the embedding;
 ///
 /// * `embedding_dim` - dimensionality of the embedding space.
-#[cfg(test)]
 pub(crate) fn evaluate_error<T>(
     p_values: &[CachePadded<T>],
     y: &[CachePadded<T>],
@@ -552,7 +551,6 @@ where
 /// * `embedding_dim` - dimensionality of the embedding space.
 ///
 /// * `theta` - threshold for the Barnes-Hut algorithm.
-#[cfg(test)]
 pub(crate) fn evaluate_error_approximately<T>(
     p_rows: &[usize],
     p_columns: &[usize],


### PR DESCRIPTION
Adds `tSNE::kl_divergence`, returning the Kullback-Leibler divergence of the current embedding (the cost t-SNE minimizes), or `None` before a fit. It is exact after `exact` and a tree approximation after `barnes_hut`. This was already computed internally for tests, this just makes the objective observable so callers can compare runs or track convergence.