### PR TITLE
Index accelerated affinities

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -28,6 +28,8 @@ jobs:
         run: curl -sSfO "https://gist.githubusercontent.com/curran/a08a1080b88344b0c8a7/raw/0e7a9b0a5d22642a06d3d5b9bcbad9890c8ee534/iris.csv"
       - name: Run tests
         run: cargo test --all-features -- --include-ignored
+      - name: Smoke-test benchmarks
+        run: cargo bench --bench affinities -- --test
 
   wasm:
     name: Wasm targets

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## Unreleased
+
+Add `tSNE::barnes_hut_with_neighbors`, an index-accelerated entry point that takes caller-supplied nearest neighbors instead of building a vantage point tree, plus the public `Neighbor` struct.
+
 ## 0.5.3
 
 Bump dependencies [(#13)](https://github.com/frjnn/bhtsne/pull/13)

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -52,4 +52,11 @@ rand = { version = "0.9", default-features = false, features = [
 getrandom = { version = "0.3.3", optional = true, features = ["wasm_js"] }
 
 [dev-dependencies]
+criterion = { version = "0.8", default-features = false, features = [
+    "cargo_bench_support",
+] }
 csv = "1.3"
+
+[[bench]]
+harness = false
+name = "affinities"

--- a/benches/affinities.rs
+++ b/benches/affinities.rs
@@ -1,0 +1,91 @@
+//! Affinity construction: `barnes_hut` (vantage point tree) vs
+//! `barnes_hut_with_neighbors` (precomputed). `epochs(0)` isolates P construction
+//! from the shared gradient descent. Neighbors are built once, outside timing.
+
+use std::hint::black_box;
+
+use bhtsne::{Neighbor, tSNE};
+use criterion::{BenchmarkId, Criterion, Throughput, criterion_group, criterion_main};
+
+const DIM: usize = 128;
+const PERPLEXITY: f32 = 30.0;
+const THETA: f32 = 0.5;
+const SIZES: [usize; 4] = [500, 1000, 2000, 4000];
+
+fn lcg_samples(n: usize, dim: usize, mut state: u64) -> Vec<f32> {
+    let mut data = Vec::with_capacity(n * dim);
+    for _ in 0..n * dim {
+        state = state
+            .wrapping_mul(6364136223846793005)
+            .wrapping_add(1442695040888963407);
+        data.push(((state >> 33) as f32 / u32::MAX as f32) - 0.5);
+    }
+    data
+}
+
+fn euclidean(a: &[f32], b: &[f32]) -> f32 {
+    a.iter()
+        .zip(b.iter())
+        .map(|(x, y)| (x - y).powi(2))
+        .sum::<f32>()
+        .sqrt()
+}
+
+fn brute_force_neighbors(samples: &[&[f32]], k: usize) -> Vec<Vec<Neighbor<f32>>> {
+    (0..samples.len())
+        .map(|i| {
+            let mut distances: Vec<(usize, f32)> = (0..samples.len())
+                .filter(|&j| j != i)
+                .map(|j| (j, euclidean(samples[i], samples[j])))
+                .collect();
+            distances.sort_by(|a, b| a.1.partial_cmp(&b.1).unwrap());
+            distances.truncate(k);
+            distances
+                .into_iter()
+                .map(|(index, distance)| Neighbor { index, distance })
+                .collect()
+        })
+        .collect()
+}
+
+fn bench_affinities(c: &mut Criterion) {
+    let k = (3.0 * PERPLEXITY) as usize;
+    let mut group = c.benchmark_group("input_affinities");
+
+    for &n in &SIZES {
+        let data = lcg_samples(n, DIM, 0x00C0_FFEE);
+        let samples: Vec<&[f32]> = data.chunks(DIM).collect();
+        let neighbors = brute_force_neighbors(&samples, k);
+
+        group.throughput(Throughput::Elements(n as u64));
+
+        // Vantage point tree path: builds the tree and queries it per sample.
+        group.bench_with_input(BenchmarkId::new("vptree", n), &n, |b, _| {
+            b.iter(|| {
+                let mut tsne = tSNE::new(&samples);
+                tsne.embedding_dim(2)
+                    .perplexity(PERPLEXITY)
+                    .epochs(0)
+                    .barnes_hut(THETA, |a, b| euclidean(a, b));
+                black_box(tsne.embedding());
+            });
+        });
+
+        // Index-accelerated path: fills the rows from precomputed neighbors.
+        group.bench_with_input(BenchmarkId::new("precomputed_neighbors", n), &n, |b, _| {
+            b.iter(|| {
+                let mut tsne = tSNE::new(&samples);
+                tsne.embedding_dim(2)
+                    .perplexity(PERPLEXITY)
+                    .epochs(0)
+                    .barnes_hut_with_neighbors(THETA, black_box(&neighbors));
+                black_box(tsne.embedding());
+            });
+        });
+    }
+
+    group.finish();
+}
+
+criterion_group!(benches, bench_affinities);
+criterion_main!(benches);

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -90,6 +90,14 @@ enum Fit<T> {
     BarnesHut { theta: T },
 }
 
+/// A sample's nearest neighbor for [`tSNE::barnes_hut_with_neighbors`]: its index
+/// and the distance (not a similarity) to it.
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub struct Neighbor<T> {
+    pub index: usize,
+    pub distance: T,
+}
+
 /// t-distributed stochastic neighbor embedding. Provides a parallel implementation of both the
 /// exact version of the algorithm and the tree accelerated one leveraging space partitioning trees.
 #[allow(non_camel_case_types)]
@@ -475,27 +483,8 @@ where
             }
         }
 
-        // Normalize P values.
-        tsne::normalize_p_values(&mut self.p_values);
-        // With no early exaggeration phase, undo the lying immediately.
-        if self.stop_lying_epoch == 0 {
-            tsne::stop_lying(&mut self.p_values);
-        }
-
-        // Seed from the supplied embedding if any, otherwise initialize randomly.
-        match self.initial_embedding.take() {
-            Some(init) => {
-                assert_eq!(
-                    init.len(),
-                    grad_entries,
-                    "error: initial embedding has {} values, expected n_samples * embedding_dim = {}",
-                    init.len(),
-                    grad_entries
-                );
-                self.y.iter_mut().zip(&init).for_each(|(y, &v)| **y = v);
-            }
-            None => tsne::random_init(&mut self.y),
-        }
+        // Normalize P, disable the early exaggeration if requested, and seed the embedding.
+        self.finalize_p_and_seed(grad_entries);
 
         // Vector used to store the mean values for each embedding dimension. It's used
         // to make the solution zero mean.
@@ -606,6 +595,42 @@ where
         self
     }
 
+    /// Normalizes P, undoes the early exaggeration if disabled, and seeds the
+    /// embedding. Shared by `exact` and `barnes_hut_fit`.
+    fn finalize_p_and_seed(&mut self, grad_entries: usize) {
+        // Normalize P values.
+        tsne::normalize_p_values(&mut self.p_values);
+        // With no early exaggeration phase, undo the lying immediately.
+        if self.stop_lying_epoch == 0 {
+            tsne::stop_lying(&mut self.p_values);
+        }
+
+        // Seed from the supplied embedding if any, otherwise initialize randomly.
+        match self.initial_embedding.take() {
+            Some(init) => {
+                assert_eq!(
+                    init.len(),
+                    grad_entries,
+                    "error: initial embedding has {} values, expected n_samples * embedding_dim = {}",
+                    init.len(),
+                    grad_entries
+                );
+                self.y.iter_mut().zip(&init).for_each(|(y, &v)| **y = v);
+            }
+            None => tsne::random_init(&mut self.y),
+        }
+    }
+
+    /// Validates `theta` and the perplexity before any expensive setup.
+    fn validate_fit_params(&self, theta: T) {
+        assert!(
+            theta > T::zero(),
+            "error: theta value must be greater than 0.0.
+            A value of 0.0 corresponds to using the exact version of the algorithm."
+        );
+        tsne::check_perplexity(&self.perplexity, &self.data.len());
+    }
+
     /// Performs a parallel Barnes-Hut approximation of the t-SNE algorithm.
     ///
     /// # Arguments
@@ -624,22 +649,101 @@ where
     where
         F: Fn(&U, &U) -> T + Send + Sync,
     {
-        // Checks that theta is valid.
-        assert!(
-            theta > T::zero(),
-            "error: theta value must be greater than 0.0. 
-            A value of 0.0 corresponds to using the exact version of the algorithm."
-        );
+        // Validate before building the tree so misuse does not pay for it first.
+        self.validate_fit_params(theta);
 
         let data = self.data;
-        let n_samples = self.data.len(); // Number of samples in data.
-
-        // Checks that the supplied perplexity is suitable for the number of samples at hand.
-        tsne::check_perplexity(&self.perplexity, &n_samples);
-
-        let embedding_dim = self.embedding_dim as usize;
-        // Number of  points ot consider when approximating the conditional distribution P.
+        // Number of points to consider when approximating the conditional distribution P.
         let n_neighbors: usize = (T::from(3.0).unwrap() * self.perplexity).as_();
+
+        // Build ball tree on the data set.
+        let tree = tsne::vptree::VPTree::new(data, &metric_f);
+
+        // The `move` closure owns the tree so `barnes_hut_fit` can drop it before
+        // the training loop. The `+ 1` is the sample itself, excluded by the search.
+        self.barnes_hut_fit(
+            theta,
+            n_neighbors,
+            move |index, p_columns_row, distances_row| {
+                tree.search(
+                    &data[index],
+                    index,
+                    n_neighbors + 1,
+                    p_columns_row,
+                    distances_row,
+                    &metric_f,
+                );
+            },
+        )
+    }
+
+    /// Like [`barnes_hut`], but uses caller-supplied nearest neighbors instead of a
+    /// vantage point tree, doing no metric evaluations. `neighbors[i]` are sample
+    /// `i`'s neighbors by ascending distance, excluding `i`, every row of equal
+    /// length `k` (used as `n_neighbors`, pick `k` near `3 * perplexity`). Indices
+    /// within a row must be distinct and distances finite and non-negative; these
+    /// are not checked.
+    ///
+    /// # Panics
+    ///
+    /// If `theta <= 0.0`, the rows are not one per sample, differ in length, are
+    /// empty, or hold an out-of-range index.
+    ///
+    /// [`barnes_hut`]: tSNE::barnes_hut
+    pub fn barnes_hut_with_neighbors(
+        &mut self,
+        theta: T,
+        neighbors: &[Vec<Neighbor<T>>],
+    ) -> &mut Self {
+        let n_samples = self.data.len();
+        assert_eq!(
+            neighbors.len(),
+            n_samples,
+            "error: neighbors has {} rows, expected one per sample = {}",
+            neighbors.len(),
+            n_samples
+        );
+
+        // Rows share one dense n_samples * k block, so all must be the same length.
+        let n_neighbors = neighbors.first().map_or(0, Vec::len);
+        assert!(
+            n_neighbors > 0 && neighbors.iter().all(|row| row.len() == n_neighbors),
+            "error: every neighbors row must have the same length, greater than zero."
+        );
+
+        // These indices later index P rows in symmetrize_sparse_matrix; reject
+        // out-of-range here instead of panicking cryptically there.
+        assert!(
+            neighbors
+                .iter()
+                .flatten()
+                .all(|neighbor| neighbor.index < n_samples),
+            "error: a neighbor index is out of range, every index must be < n_samples = {n_samples}."
+        );
+
+        self.barnes_hut_fit(theta, n_neighbors, |index, p_columns_row, distances_row| {
+            p_columns_row
+                .iter_mut()
+                .zip(distances_row.iter_mut())
+                .zip(neighbors[index].iter())
+                .for_each(|((column, distance), neighbor)| {
+                    **column = neighbor.index;
+                    **distance = neighbor.distance;
+                });
+        })
+    }
+
+    /// Shared Barnes-Hut fit. `fill_neighbors(index, p_columns_row, distances_row)`
+    /// writes sample `index`'s neighbor indices and distances; the rest is common.
+    fn barnes_hut_fit<F>(&mut self, theta: T, n_neighbors: usize, fill_neighbors: F) -> &mut Self
+    where
+        F: Fn(usize, &mut [CachePadded<usize>], &mut [CachePadded<T>]) + Send + Sync,
+    {
+        // Idempotent: `barnes_hut` already validated before building its tree.
+        self.validate_fit_params(theta);
+
+        let n_samples = self.data.len(); // Number of samples in data.
+        let embedding_dim = self.embedding_dim as usize;
         // NUmber of entries in gradient and gains matrices.
         let grad_entries = n_samples * embedding_dim;
         // Number of entries in pairwise measures matrices.
@@ -664,41 +768,27 @@ where
         // to p_values[i][j]. This vector is freed inside symmetrize_sparse_matrix.
         let mut p_columns: Vec<CachePadded<usize>> = vec![0.into(); pairwise_entries];
 
-        // Computes sparse input similarities using a vantage point tree.
+        // Fill the neighbor rows, then fit the per-point Gaussian bandwidth.
         {
             // Distances buffer.
             let mut distances: Vec<CachePadded<T>> = vec![T::zero().into(); pairwise_entries];
 
-            // Build ball tree on data set. The tree is freed at the end of the scope.
-            let tree = tsne::vptree::VPTree::new(data, &metric_f);
-
-            // For each sample in the dataset compute the perplexities using a vantage point tree
-            // in parallel.
-            {
-                let perplexity = &self.perplexity; // Immutable borrow must be outside.
-                self.p_values
-                    .par_chunks_mut(n_neighbors)
-                    .zip(distances.par_chunks_mut(n_neighbors))
-                    .zip(p_columns.par_chunks_mut(n_neighbors))
-                    .zip(data.par_iter())
-                    .enumerate()
-                    .for_each(
-                        |(index, (((p_values_row, distances_row), p_columns_row), sample))| {
-                            // Writes the indices and the distances of the nearest neighbors of sample.
-                            tree.search(
-                                sample,
-                                index,
-                                n_neighbors + 1, // The first NN is sample itself.
-                                p_columns_row,
-                                distances_row,
-                                &metric_f,
-                            );
-                            debug_assert!(!p_columns_row.iter().any(|&i| *i == index));
-                            tsne::search_beta(p_values_row, distances_row, perplexity);
-                        },
-                    );
-            }
+            let perplexity = &self.perplexity; // Immutable borrow must be outside.
+            self.p_values
+                .par_chunks_mut(n_neighbors)
+                .zip(distances.par_chunks_mut(n_neighbors))
+                .zip(p_columns.par_chunks_mut(n_neighbors))
+                .enumerate()
+                .for_each(|(index, ((p_values_row, distances_row), p_columns_row))| {
+                    // Writes the indices and the distances of the nearest neighbors of the sample.
+                    fill_neighbors(index, p_columns_row, distances_row);
+                    debug_assert!(!p_columns_row.iter().any(|&i| *i == index));
+                    tsne::search_beta(p_values_row, distances_row, perplexity);
+                });
         }
+
+        // Free whatever the filler owns (the vantage point tree) before training.
+        drop(fill_neighbors);
 
         // Symmetrize sparse P matrix.
         tsne::symmetrize_sparse_matrix(
@@ -710,27 +800,8 @@ where
             &n_neighbors,
         );
 
-        // Normalize P values.
-        tsne::normalize_p_values(&mut self.p_values);
-        // With no early exaggeration phase, undo the lying immediately.
-        if self.stop_lying_epoch == 0 {
-            tsne::stop_lying(&mut self.p_values);
-        }
-
-        // Seed from the supplied embedding if any, otherwise initialize randomly.
-        match self.initial_embedding.take() {
-            Some(init) => {
-                assert_eq!(
-                    init.len(),
-                    grad_entries,
-                    "error: initial embedding has {} values, expected n_samples * embedding_dim = {}",
-                    init.len(),
-                    grad_entries
-                );
-                self.y.iter_mut().zip(&init).for_each(|(y, &v)| **y = v);
-            }
-            None => tsne::random_init(&mut self.y),
-        }
+        // Normalize P, disable the early exaggeration if requested, and seed the embedding.
+        self.finalize_p_and_seed(grad_entries);
 
         // Prepares buffers for Barnes-Hut algorithm.
         let mut positive_forces: Vec<CachePadded<T>> = vec![T::zero().into(); grad_entries];

--- a/src/test.rs
+++ b/src/test.rs
@@ -1,6 +1,6 @@
 use crossbeam::utils::CachePadded;
 
-use super::{tSNE, tsne};
+use super::{Neighbor, tSNE, tsne};
 
 const D: usize = 4;
 const THETA: f32 = 0.5;
@@ -661,6 +661,125 @@ fn stop_lying_epoch_zero_skips_exaggeration_exact() {
         truthful < exaggerated / 3.0,
         "first epoch still exaggerated: moved {truthful} against {exaggerated} with 12x P values"
     );
+}
+
+/// Euclidean distance between two samples, the metric the Barnes-Hut tests use.
+fn euclidean(a: &[f32], b: &[f32]) -> f32 {
+    a.iter()
+        .zip(b.iter())
+        .map(|(x, y)| (x - y).powi(2))
+        .sum::<f32>()
+        .sqrt()
+}
+
+/// Exact k nearest neighbors per sample, sorted by ascending distance, excluding
+/// self: the same set the vantage point tree finds.
+fn brute_force_neighbors(samples: &[&[f32]], n_neighbors: usize) -> Vec<Vec<Neighbor<f32>>> {
+    (0..samples.len())
+        .map(|i| {
+            let mut distances: Vec<(usize, f32)> = (0..samples.len())
+                .filter(|&j| j != i)
+                .map(|j| (j, euclidean(samples[i], samples[j])))
+                .collect();
+            distances.sort_by(|a, b| a.1.partial_cmp(&b.1).unwrap());
+            distances.truncate(n_neighbors);
+            distances
+                .into_iter()
+                .map(|(index, distance)| Neighbor { index, distance })
+                .collect()
+        })
+        .collect()
+}
+
+/// Fed the neighbors the tree would find, `barnes_hut_with_neighbors` must
+/// reproduce the `barnes_hut` embedding bit for bit (the pipeline is deterministic).
+#[test]
+fn barnes_hut_with_neighbors_matches_vptree_path() {
+    const N: usize = 80;
+    const DIM: usize = 4;
+
+    let data = lcg_samples(N, DIM, 11);
+    let samples: Vec<&[f32]> = data.chunks(DIM).collect();
+
+    // A seed so both fits start from the very same embedding.
+    let seed = lcg_samples(N, NO_DIMS as usize, 99);
+
+    // Pin to one rayon thread: the parallel reductions in the fit accumulate in a
+    // thread-count dependent order, which the chaotic gradient descent would
+    // amplify, so single threaded keeps both paths bitwise reproducible.
+    let pool = rayon::ThreadPoolBuilder::new()
+        .num_threads(1)
+        .build()
+        .unwrap();
+
+    let reference = pool.install(|| {
+        let mut tsne = tSNE::new(&samples);
+        tsne.embedding_dim(NO_DIMS)
+            .perplexity(PERPLEXITY)
+            .epochs(100)
+            .initial_embedding(&seed[..])
+            .barnes_hut(THETA, |a, b| euclidean(a, b));
+        tsne.embedding()
+    });
+
+    let n_neighbors = (3.0 * PERPLEXITY) as usize;
+    let neighbors = brute_force_neighbors(&samples, n_neighbors);
+
+    let candidate = pool.install(|| {
+        let mut tsne = tSNE::new(&samples);
+        tsne.embedding_dim(NO_DIMS)
+            .perplexity(PERPLEXITY)
+            .epochs(100)
+            .initial_embedding(&seed[..])
+            .barnes_hut_with_neighbors(THETA, &neighbors);
+        tsne.embedding()
+    });
+
+    assert_eq!(candidate, reference);
+}
+
+/// Ragged neighbor rows must be rejected.
+#[test]
+#[should_panic(expected = "same length")]
+fn barnes_hut_with_neighbors_rejects_ragged_rows() {
+    const N: usize = 80;
+    const DIM: usize = 4;
+
+    let data = lcg_samples(N, DIM, 11);
+    let samples: Vec<&[f32]> = data.chunks(DIM).collect();
+
+    let n_neighbors = (3.0 * PERPLEXITY) as usize;
+    let mut neighbors = brute_force_neighbors(&samples, n_neighbors);
+    // Make one row shorter than the others.
+    neighbors[0].pop();
+
+    let mut tsne = tSNE::new(&samples);
+    tsne.embedding_dim(NO_DIMS)
+        .perplexity(PERPLEXITY)
+        .epochs(1)
+        .barnes_hut_with_neighbors(THETA, &neighbors);
+}
+
+/// An out-of-range neighbor index must be rejected up front.
+#[test]
+#[should_panic(expected = "out of range")]
+fn barnes_hut_with_neighbors_rejects_out_of_range_index() {
+    const N: usize = 80;
+    const DIM: usize = 4;
+
+    let data = lcg_samples(N, DIM, 11);
+    let samples: Vec<&[f32]> = data.chunks(DIM).collect();
+
+    let n_neighbors = (3.0 * PERPLEXITY) as usize;
+    let mut neighbors = brute_force_neighbors(&samples, n_neighbors);
+    // Point one neighbor at a sample that does not exist.
+    neighbors[0][0].index = N;
+
+    let mut tsne = tSNE::new(&samples);
+    tsne.embedding_dim(NO_DIMS)
+        .perplexity(PERPLEXITY)
+        .epochs(1)
+        .barnes_hut_with_neighbors(THETA, &neighbors);
 }
 
 /// Deterministic LCG data so the tests need no RNG dependency.


### PR DESCRIPTION
Adds `tSNE::barnes_hut_with_neighbors`, which takes precomputed nearest neighbors instead of building a vantage point tree, plus the public `Neighbor` struct. Both paths share one `barnes_hut_fit`, so everything after the neighbor search (bandwidth fit, symmetrization, gradient descent) is unchanged. A test feeds the neighbors the tree would find and asserts a bit-for-bit identical embedding.

This lets me exploits similarity indices I have already created for MS/MS spectra and molecules.

| N | VP-tree metric evals (dim=256) | / N^2 |
|---|---|---|
| 1000 | 1.05e6 | 1.05 |
| 8000 | 6.46e7 | 1.01 |
| 32000 | 1.03e9 | 1.003 |

A FLASH-style inverted index already returns top-k for these similarities in roughly one pass. This entry point lets that index feed t-SNE directly, so the affinity step does no metric evaluations at all.

<img width="1806" height="797" alt="image" src="https://github.com/user-attachments/assets/e374576f-68ca-44db-8429-a6e5368be5b0" />

Adds `benches/affinities.rs` (criterion) comparing the two paths, plus a CI step running it in test mode (`cargo bench --bench affinities -- --test`) so it stays compiling and runnable.
