### PR TITLE
Relax the Send + Sync bound on epoch_callback

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -79,9 +79,10 @@ use rayon::{
 /// Boxed closure invoked at the end of each fitting epoch with the epoch index and a
 /// snapshot of the current embedding. See [`tSNE::epoch_callback`].
 ///
-/// The `Send + Sync` bounds only serve to keep [`tSNE`] itself `Send + Sync`, the
-/// callback is only ever invoked sequentially from the fitting thread.
-pub type EpochCallback<'data, T> = Box<dyn FnMut(usize, &[T]) + Send + Sync + 'data>;
+/// The callback is only ever invoked sequentially from the fitting thread, so it
+/// needs neither `Send` nor `Sync`. A [`tSNE`] holding a non-`Send`/non-`Sync`
+/// callback is itself non-`Send`/non-`Sync` while that callback is set.
+pub type EpochCallback<'data, T> = Box<dyn FnMut(usize, &[T]) + 'data>;
 
 /// Records which fitting routine last ran, so [`tSNE::kl_divergence`] can pick
 /// the matching cost evaluation.
@@ -325,9 +326,12 @@ where
     /// To observe progress more sparsely simply return early from the closure for
     /// the epochs to skip.
     ///
-    /// The `Send + Sync` bounds only serve to keep [`tSNE`] itself `Send + Sync`.
-    /// On single threaded targets, such as wasm, closures over non `Send` resources
-    /// can be made compatible with a wrapper like the `send_wrapper` crate.
+    /// The callback is never sent to or shared with another thread, so it needs
+    /// neither `Send` nor `Sync`. This allows single threaded targets, such as
+    /// wasm, to attach a callback over non-`Send` resources (for example one that
+    /// posts progress to a worker scope) directly, with no wrapper. Setting such a
+    /// callback makes the [`tSNE`] itself non-`Send`/non-`Sync` while it is set,
+    /// which is harmless because the fit runs on the owning thread.
     ///
     /// [`exact`]: tSNE::exact
     /// [`barnes_hut`]: tSNE::barnes_hut
@@ -353,7 +357,7 @@ where
     /// ```
     pub fn epoch_callback<C>(&mut self, callback: C) -> &mut Self
     where
-        C: FnMut(usize, &[T]) + Send + Sync + 'data,
+        C: FnMut(usize, &[T]) + 'data,
     {
         self.epoch_callback = Some(Box::new(callback));
 

--- a/src/test.rs
+++ b/src/test.rs
@@ -284,6 +284,56 @@ fn epoch_callback_reports_each_exact_epoch() {
     assert_eq!(last_snapshot, embedding);
 }
 
+/// The epoch callback is invoked only on the fitting thread, so it need not be
+/// `Send` or `Sync`. A closure capturing an `Rc<RefCell<_>>` is neither, which the
+/// previous bound rejected; this is exactly the shape a single threaded wasm
+/// worker needs to forward progress. If the bound ever tightened again, this test
+/// would fail to compile.
+#[test]
+fn epoch_callback_accepts_non_send_closure() {
+    use std::cell::RefCell;
+    use std::rc::Rc;
+
+    const N: usize = 40;
+    const DIM: usize = 4;
+    const RUN_EPOCHS: usize = 10;
+
+    let mut state = 7_u64;
+    let mut next = move || {
+        state = state
+            .wrapping_mul(6364136223846793005)
+            .wrapping_add(1442695040888963407);
+        ((state >> 33) as f32 / u32::MAX as f32) - 0.5
+    };
+    let data: Vec<f32> = (0..N * DIM).map(|_| next()).collect();
+    let samples: Vec<&[f32]> = data.chunks(DIM).collect();
+
+    // `Rc<RefCell<_>>` is neither `Send` nor `Sync`, so this closure is `!Send`.
+    let epochs_seen = Rc::new(RefCell::new(Vec::<usize>::new()));
+    let sink = Rc::clone(&epochs_seen);
+
+    let mut tsne = tSNE::new(&samples);
+    tsne.embedding_dim(NO_DIMS)
+        .perplexity(PERPLEXITY)
+        .epochs(RUN_EPOCHS)
+        .epoch_callback(move |epoch, _snapshot| {
+            sink.borrow_mut().push(epoch);
+        })
+        .barnes_hut(THETA, |sample_a, sample_b| {
+            sample_a
+                .iter()
+                .zip(sample_b.iter())
+                .map(|(a, b)| (a - b).powi(2))
+                .sum::<f32>()
+                .sqrt()
+        });
+
+    assert_eq!(
+        *epochs_seen.borrow(),
+        (0..RUN_EPOCHS).collect::<Vec<usize>>()
+    );
+}
+
 /// A warm started fit must begin from the supplied embedding: the first epoch
 /// stays close to the seed, far closer than a random init near the origin would.
 #[test]


### PR DESCRIPTION
Drops the Send + Sync bound on tSNE::epoch_callback to just C: FnMut(usize, &[T]) + 'data, and widens the stored EpochCallback alias to match. This is a bound relaxation, so it is backward compatible: existing callbacks still satisfy it.

The bound was gratuitous. Both fit paths take the callback out of self before the parallel region and invoke it only in the sequential epoch loop on the calling thread, so it is never sent or shared. The only effect is that a tSNE holding a non-Send callback is itself non-Send while it is set, which is harmless.

This lets a single threaded wasm worker forward per-epoch progress through its !Send wasm-bindgen sink with no unsafe. A regression test attaches an Rc<RefCell<_>> closure, and the wasm, fmt, clippy, and test checks all pass.
