### PR TITLE
Speed up t-SNE by storing working buffers densely

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## 0.5.11
+
+Store the working buffers as dense `Vec<T>` instead of wrapping every scalar in `CachePadded`, which had put each value on its own 128 byte cache line and blocked vectorization. The exact gradient loop is several times faster and the Barnes-Hut path is faster as well, for both `f32` and `f64`, with bitwise identical embeddings. The Barnes-Hut force loop now accumulates into thread local scratch and writes once to avoid false sharing. Drops the `crossbeam` dependency and adds a criterion benchmark of the optimization loop.
+
 ## 0.5.9
 
 Add `tSNE::barnes_hut_with_neighbors`, an index-accelerated entry point that takes caller-supplied nearest neighbors instead of building a vantage point tree, plus the public `Neighbor` struct.

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -56,7 +56,12 @@ criterion = { version = "0.8", default-features = false, features = [
     "cargo_bench_support",
 ] }
 csv = "1.3"
+num-traits = "0.2"
 
 [[bench]]
 harness = false
 name = "affinities"
+
+[[bench]]
+harness = false
+name = "tsne"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -30,7 +30,6 @@ wasm_js = ["dep:getrandom", "rand/thread_rng"]
 unsafe_code = "forbid"
 
 [dependencies]
-crossbeam = "0.8"
 csv = { version = "1", optional = true }
 num-traits = "0.2"
 rand_distr = "0.5"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,7 +15,7 @@ license = "MIT"
 name = "bhtsne"
 readme = "README.md"
 repository = "https://github.com/frjnn/bhtsne"
-version = "0.5.10"
+version = "0.5.11"
 
 [features]
 default = ["csv"]

--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@ Additional implementations of the algorithm, including this one, are listed at [
 Add this line to your `Cargo.toml`:
 ```toml
 [dependencies]
-bhtsne = "0.5.10"
+bhtsne = "0.5.11"
 ```
 ### Documentation
 

--- a/benches/tsne.rs
+++ b/benches/tsne.rs
@@ -1,0 +1,134 @@
+//! Benchmarks the t-SNE optimization loop (gradient descent and force
+//! computation), excluding the nearest neighbor index: the Barnes-Hut path runs
+//! from neighbors precomputed outside the timed section. Both `f32` and `f64`
+//! are measured, each at zero epochs (setup only) and at `EPOCHS`, so the
+//! per-epoch loop cost is the difference.
+
+use std::hint::black_box;
+use std::iter::Sum;
+use std::ops::{AddAssign, DivAssign, MulAssign, SubAssign};
+
+use bhtsne::{Neighbor, tSNE};
+use criterion::measurement::WallTime;
+use criterion::{BenchmarkGroup, BenchmarkId, Criterion, criterion_group, criterion_main};
+use num_traits::{AsPrimitive, Float};
+
+const INPUT_DIM: usize = 50;
+const EMBED_DIM: u8 = 2;
+const PERPLEXITY: f64 = 30.0;
+const THETA: f64 = 0.5;
+const EPOCHS: usize = 100;
+
+/// The scalar bound bundle the t-SNE solver requires, satisfied by both floats.
+trait Scalar:
+    Float + Send + Sync + AsPrimitive<usize> + Sum + DivAssign + AddAssign + MulAssign + SubAssign
+{
+}
+impl Scalar for f32 {}
+impl Scalar for f64 {}
+
+fn cast<T: Float>(x: f64) -> T {
+    T::from(x).unwrap()
+}
+
+/// Deterministic pseudo random samples, reproducible and RNG-free.
+fn lcg<T: Scalar>(n: usize, dim: usize, mut state: u64) -> Vec<T> {
+    let mut data = Vec::with_capacity(n * dim);
+    for _ in 0..n * dim {
+        state = state
+            .wrapping_mul(6364136223846793005)
+            .wrapping_add(1442695040888963407);
+        data.push(cast((state >> 33) as f64 / u32::MAX as f64 - 0.5));
+    }
+    data
+}
+
+fn sq_euclidean<T: Scalar>(a: &[T], b: &[T]) -> T {
+    a.iter().zip(b.iter()).map(|(&x, &y)| (x - y).powi(2)).sum()
+}
+
+fn euclidean<T: Scalar>(a: &[T], b: &[T]) -> T {
+    sq_euclidean(a, b).sqrt()
+}
+
+/// Exact k nearest neighbors per sample, ascending distance, excluding self.
+/// Built once, outside the timed section.
+fn brute_force_neighbors<T: Scalar>(samples: &[&[T]], k: usize) -> Vec<Vec<Neighbor<T>>> {
+    (0..samples.len())
+        .map(|i| {
+            let mut distances: Vec<(usize, T)> = (0..samples.len())
+                .filter(|&j| j != i)
+                .map(|j| (j, euclidean(samples[i], samples[j])))
+                .collect();
+            distances.sort_by(|a, b| a.1.partial_cmp(&b.1).unwrap());
+            distances.truncate(k);
+            distances
+                .into_iter()
+                .map(|(index, distance)| Neighbor { index, distance })
+                .collect()
+        })
+        .collect()
+}
+
+fn bench_exact<T: Scalar>(group: &mut BenchmarkGroup<'_, WallTime>, dtype: &str) {
+    for &n in &[250usize, 500] {
+        let data: Vec<T> = lcg(n, INPUT_DIM, 0x00C0_FFEE);
+        let samples: Vec<&[T]> = data.chunks(INPUT_DIM).collect();
+
+        for &epochs in &[0usize, EPOCHS] {
+            let id = BenchmarkId::new(format!("{dtype}/n{n}"), epochs);
+            group.bench_with_input(id, &epochs, |b, &e| {
+                b.iter(|| {
+                    let mut tsne = tSNE::new(&samples);
+                    tsne.embedding_dim(EMBED_DIM)
+                        .perplexity(cast(PERPLEXITY))
+                        .epochs(e)
+                        .exact(|a, b| sq_euclidean(a, b));
+                    black_box(tsne.embedding());
+                });
+            });
+        }
+    }
+}
+
+fn bench_barnes_hut<T: Scalar>(group: &mut BenchmarkGroup<'_, WallTime>, dtype: &str) {
+    let k = (3.0 * PERPLEXITY) as usize;
+    for &n in &[1000usize, 2000] {
+        let data: Vec<T> = lcg(n, INPUT_DIM, 0x00C0_FFEE);
+        let samples: Vec<&[T]> = data.chunks(INPUT_DIM).collect();
+        let neighbors = brute_force_neighbors(&samples, k);
+
+        for &epochs in &[0usize, EPOCHS] {
+            let id = BenchmarkId::new(format!("{dtype}/n{n}"), epochs);
+            group.bench_with_input(id, &epochs, |b, &e| {
+                b.iter(|| {
+                    let mut tsne = tSNE::new(&samples);
+                    tsne.embedding_dim(EMBED_DIM)
+                        .perplexity(cast(PERPLEXITY))
+                        .epochs(e)
+                        .barnes_hut_with_neighbors(cast(THETA), black_box(&neighbors));
+                    black_box(tsne.embedding());
+                });
+            });
+        }
+    }
+}
+
+fn exact(c: &mut Criterion) {
+    let mut group = c.benchmark_group("tsne_exact");
+    group.sample_size(10);
+    bench_exact::<f32>(&mut group, "f32");
+    bench_exact::<f64>(&mut group, "f64");
+    group.finish();
+}
+
+fn barnes_hut(c: &mut Criterion) {
+    let mut group = c.benchmark_group("tsne_barnes_hut");
+    group.sample_size(10);
+    bench_barnes_hut::<f32>(&mut group, "f32");
+    bench_barnes_hut::<f64>(&mut group, "f64");
+    group.finish();
+}
+
+criterion_group!(benches, exact, barnes_hut);
+criterion_main!(benches);

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -66,8 +66,6 @@ use std::{error::Error, fs::File};
 
 use num_traits::{Float, cast::AsPrimitive};
 
-use crossbeam::utils::CachePadded;
-
 use rayon::{
     iter::{
         IndexedParallelIterator, IntoParallelRefIterator, IntoParallelRefMutIterator,
@@ -116,14 +114,14 @@ where
     stop_lying_epoch: usize,
     embedding_dim: u8,
     perplexity: T,
-    p_values: Vec<CachePadded<T>>,
+    p_values: Vec<T>,
     p_rows: Vec<usize>,
     p_columns: Vec<usize>,
-    q_values: Vec<CachePadded<T>>,
-    y: Vec<CachePadded<T>>,
-    dy: Vec<CachePadded<T>>,
-    uy: Vec<CachePadded<T>>,
-    gains: Vec<CachePadded<T>>,
+    q_values: Vec<T>,
+    y: Vec<T>,
+    dy: Vec<T>,
+    uy: Vec<T>,
+    gains: Vec<T>,
     epoch_callback: Option<EpochCallback<'data, T>>,
     initial_embedding: Option<Vec<T>>,
     fit: Option<Fit<T>>,
@@ -379,7 +377,7 @@ where
 
     /// Returns the computed embedding.
     pub fn embedding(&self) -> Vec<T> {
-        self.y.iter().map(|x| **x).collect()
+        self.y.clone()
     }
 
     /// Returns the Kullback-Leibler divergence of the current embedding, the cost
@@ -442,16 +440,16 @@ where
             grad_entries,
         );
         // Prepare distributions matrices.
-        self.p_values.resize(pairwise_entries, T::zero().into()); // P.
-        self.q_values.resize(pairwise_entries, T::zero().into()); // Q.
+        self.p_values.resize(pairwise_entries, T::zero()); // P.
+        self.q_values.resize(pairwise_entries, T::zero()); // Q.
 
         // Alignment prevents false sharing.
-        let mut distances: Vec<CachePadded<T>> = vec![T::zero().into(); pairwise_entries];
+        let mut distances: Vec<T> = vec![T::zero(); pairwise_entries];
         // Zeroes the diagonal entries. The distances vector is recycled but the elements
         // corresponding to the diagonal entries of the distance matrix are always kept to 0. and
         // never written on. This hold as an invariant through all the algorithm.
         for i in 0..n_samples {
-            distances[i * n_samples + i] = T::zero().into();
+            distances[i * n_samples + i] = T::zero();
         }
 
         // Compute pairwise distances in parallel with the user supplied function.
@@ -481,9 +479,9 @@ where
         // obtain the joint P distribution.
         for i in 0..n_samples {
             for j in (i + 1)..n_samples {
-                let symmetric = *self.p_values[j * n_samples + i];
-                *self.p_values[i * n_samples + j] += symmetric;
-                *self.p_values[j * n_samples + i] = *self.p_values[i * n_samples + j];
+                let symmetric = self.p_values[j * n_samples + i];
+                self.p_values[i * n_samples + j] += symmetric;
+                self.p_values[j * n_samples + i] = self.p_values[i * n_samples + j];
             }
         }
 
@@ -508,10 +506,10 @@ where
             // Compute pairwise squared euclidean distances between embeddings in parallel.
             tsne::compute_pairwise_distance_matrix(
                 &mut distances,
-                |ith: &[CachePadded<T>], jth: &[CachePadded<T>]| {
+                |ith: &[T], jth: &[T]| {
                     ith.iter()
                         .zip(jth.iter())
-                        .map(|(&i, &j)| (*i - *j).powi(2))
+                        .map(|(&i, &j)| (i - j).powi(2))
                         .sum()
                 },
                 |index| &self.y[index * embedding_dim..index * embedding_dim + embedding_dim],
@@ -522,10 +520,10 @@ where
             self.q_values
                 .par_iter_mut()
                 .zip(distances.par_iter())
-                .for_each(|(q, d)| **q = T::one() / (T::one() + **d));
+                .for_each(|(q, d)| *q = T::one() / (T::one() + *d));
 
             // Computes the exact gradient in parallel.
-            let q_values_sum: T = self.q_values.par_iter().map(|&q| *q).sum();
+            let q_values_sum: T = self.q_values.par_iter().map(|&q| q).sum();
 
             // Immutable borrow to self must happen outside of the inner sequential
             // loop. The outer parallel loop already has a mutable borrow.
@@ -542,13 +540,13 @@ where
                             .zip(q_values_sample.iter())
                             .zip(y.chunks(embedding_dim))
                             .for_each(|((&p, &q), other_sample)| {
-                                let m: T = (*p - *q / q_values_sum) * *q;
+                                let m: T = (p - q / q_values_sum) * q;
                                 dy_sample
                                     .iter_mut()
                                     .zip(y_sample.iter())
                                     .zip(other_sample.iter())
                                     .for_each(|((dy_el, &y_el), &other_el)| {
-                                        **dy_el += (*y_el - *other_el) * m
+                                        *dy_el += (y_el - other_el) * m
                                     });
                             });
                     },
@@ -565,7 +563,7 @@ where
             );
 
             // Zeroes the gradient.
-            self.dy.iter_mut().for_each(|el| **el = T::zero());
+            self.dy.iter_mut().for_each(|el| *el = T::zero());
 
             // Make solution zero mean.
             tsne::zero_mean(&mut means, &mut self.y, n_samples, embedding_dim);
@@ -586,7 +584,7 @@ where
                 snapshot
                     .iter_mut()
                     .zip(self.y.iter())
-                    .for_each(|(dst, src)| *dst = **src);
+                    .for_each(|(dst, src)| *dst = *src);
                 callback(epoch, &snapshot);
             }
         }
@@ -619,7 +617,7 @@ where
                     init.len(),
                     grad_entries
                 );
-                self.y.iter_mut().zip(&init).for_each(|(y, &v)| **y = v);
+                self.y.iter_mut().zip(&init).for_each(|(y, &v)| *y = v);
             }
             None => tsne::random_init(&mut self.y),
         }
@@ -731,8 +729,8 @@ where
                 .zip(distances_row.iter_mut())
                 .zip(neighbors[index].iter())
                 .for_each(|((column, distance), neighbor)| {
-                    **column = neighbor.index;
-                    **distance = neighbor.distance;
+                    *column = neighbor.index;
+                    *distance = neighbor.distance;
                 });
         })
     }
@@ -741,7 +739,7 @@ where
     /// writes sample `index`'s neighbor indices and distances; the rest is common.
     fn barnes_hut_fit<F>(&mut self, theta: T, n_neighbors: usize, fill_neighbors: F) -> &mut Self
     where
-        F: Fn(usize, &mut [CachePadded<usize>], &mut [CachePadded<T>]) + Send + Sync,
+        F: Fn(usize, &mut [usize], &mut [T]) + Send + Sync,
     {
         // Idempotent: `barnes_hut` already validated before building its tree.
         self.validate_fit_params(theta);
@@ -763,19 +761,19 @@ where
         );
         // The P distribution values are restricted to a subset of size n_neighbors for each input
         // sample.
-        self.p_values.resize(pairwise_entries, T::zero().into());
+        self.p_values.resize(pairwise_entries, T::zero());
 
         // This vector is used to keep track of the indexes for each nearest neighbors of each
         // sample. There's a one to one correspondence between the elements of p_columns
         // an the elements of p_values: for each row i of length n_neighbors of such matrices it
         // holds that p_columns[i][j] corresponds to the index sample which contributes
         // to p_values[i][j]. This vector is freed inside symmetrize_sparse_matrix.
-        let mut p_columns: Vec<CachePadded<usize>> = vec![0.into(); pairwise_entries];
+        let mut p_columns: Vec<usize> = vec![0usize; pairwise_entries];
 
         // Fill the neighbor rows, then fit the per-point Gaussian bandwidth.
         {
             // Distances buffer.
-            let mut distances: Vec<CachePadded<T>> = vec![T::zero().into(); pairwise_entries];
+            let mut distances: Vec<T> = vec![T::zero(); pairwise_entries];
 
             let perplexity = &self.perplexity; // Immutable borrow must be outside.
             self.p_values
@@ -786,7 +784,7 @@ where
                 .for_each(|(index, ((p_values_row, distances_row), p_columns_row))| {
                     // Writes the indices and the distances of the nearest neighbors of the sample.
                     fill_neighbors(index, p_columns_row, distances_row);
-                    debug_assert!(!p_columns_row.iter().any(|&i| *i == index));
+                    debug_assert!(!p_columns_row.contains(&index));
                     tsne::search_beta(p_values_row, distances_row, perplexity);
                 });
         }
@@ -808,10 +806,9 @@ where
         self.finalize_p_and_seed(grad_entries);
 
         // Prepares buffers for Barnes-Hut algorithm.
-        let mut positive_forces: Vec<CachePadded<T>> = vec![T::zero().into(); grad_entries];
-        let mut negative_forces: Vec<CachePadded<T>> = vec![T::zero().into(); grad_entries];
-        let mut forces_buffer: Vec<CachePadded<T>> = vec![T::zero().into(); grad_entries];
-        let mut q_sums: Vec<CachePadded<T>> = vec![T::zero().into(); n_samples];
+        let mut positive_forces: Vec<T> = vec![T::zero(); grad_entries];
+        let mut negative_forces: Vec<T> = vec![T::zero(); grad_entries];
+        let mut q_sums: Vec<T> = vec![T::zero(); n_samples];
 
         // Vector used to store the mean values for each embedding dimension. It's used
         // to make the solution zero mean.
@@ -838,58 +835,60 @@ where
                 // Each chunk of positive_forces and negative_forces is associated to a distinct
                 // embedded sample in y. As a consequence of this the computation can be done in
                 // parallel.
-                positive_forces
-                    .par_chunks_mut(embedding_dim)
+                self.y
+                    .par_chunks(embedding_dim)
+                    .zip(positive_forces.par_chunks_mut(embedding_dim))
                     .zip(negative_forces.par_chunks_mut(embedding_dim))
-                    .zip(forces_buffer.par_chunks_mut(embedding_dim))
                     .zip(q_sums.par_iter_mut())
-                    .zip(self.y.par_chunks(embedding_dim))
                     .enumerate()
-                    .for_each(
-                        |(
-                            index,
+                    .for_each_init(
+                        || {
                             (
-                                (
-                                    ((positive_forces_row, negative_forces_row), forces_buffer_row),
-                                    q_sum,
-                                ),
-                                sample,
-                            ),
-                        )| {
+                                vec![T::zero(); embedding_dim],
+                                vec![T::zero(); embedding_dim],
+                                vec![T::zero(); embedding_dim],
+                            )
+                        },
+                        |(edge_row, nonedge_row, buffer_row),
+                         (index, (((sample, positive_out), negative_out), q_sum_out))| {
+                            // Accumulate into thread local scratch and write once, so the
+                            // per-sample updates during traversal do not false share.
+                            edge_row.iter_mut().for_each(|f| *f = T::zero());
+                            nonedge_row.iter_mut().for_each(|f| *f = T::zero());
+                            let mut q_sum = T::zero();
                             tree.compute_edge_forces(
                                 index,
                                 sample,
                                 &self.p_rows,
                                 &self.p_columns,
                                 &self.p_values,
-                                forces_buffer_row,
-                                positive_forces_row,
+                                buffer_row,
+                                edge_row,
                             );
                             tree.compute_non_edge_forces(
                                 index,
                                 theta,
-                                negative_forces_row,
-                                forces_buffer_row,
-                                q_sum,
+                                nonedge_row,
+                                buffer_row,
+                                &mut q_sum,
                             );
+                            positive_out.copy_from_slice(edge_row);
+                            negative_out.copy_from_slice(nonedge_row);
+                            *q_sum_out = q_sum;
                         },
                     );
             }
 
             // Compute final Barnes-Hut t-SNE gradient approximation.
             // Reduces partial sums of Q distribution.
-            let q_sum: T = q_sums.par_iter_mut().map(|sum| **sum).sum();
+            let q_sum: T = q_sums.par_iter().map(|sum| *sum).sum();
             self.dy
                 .par_iter_mut()
-                .zip(positive_forces.par_iter_mut())
-                .zip(negative_forces.par_iter_mut())
+                .zip(positive_forces.par_iter())
+                .zip(negative_forces.par_iter())
                 .for_each(|((grad, pf), nf)| {
-                    **grad = **pf - (**nf / q_sum);
-                    **pf = T::zero();
-                    **nf = T::zero();
+                    *grad = *pf - (*nf / q_sum);
                 });
-            // Zeroes Q-sums.
-            q_sums.iter_mut().for_each(|sum| **sum = T::zero());
 
             // Updates the embedding in parallel with gradient descent.
             tsne::update_solution(
@@ -920,7 +919,7 @@ where
                 snapshot
                     .iter_mut()
                     .zip(self.y.iter())
-                    .for_each(|(dst, src)| *dst = **src);
+                    .for_each(|(dst, src)| *dst = *src);
                 callback(epoch, &snapshot);
             }
         }
@@ -958,7 +957,7 @@ where
         let to_write = self
             .y
             .iter()
-            .map(|&el| (*el).to_string())
+            .map(|&el| el.to_string())
             .collect::<Vec<String>>();
 
         // Write headers.

--- a/src/test.rs
+++ b/src/test.rs
@@ -1,5 +1,3 @@
-use crossbeam::utils::CachePadded;
-
 use super::{Neighbor, tSNE, tsne};
 
 const D: usize = 4;
@@ -887,10 +885,10 @@ fn bounding_box_diagonal(points: &[f32], dim: usize) -> f32 {
 fn search_beta_converges_when_optimal_beta_below_one() {
     // 90 neighbours (3 * perplexity) with squared distances spread over
     // [20, 120]: the optimal beta for perplexity 30 is roughly 0.08.
-    let distances_row: Vec<CachePadded<f64>> = (0..90)
-        .map(|i| CachePadded::new((20.0 + 100.0 * (i as f64 + 1.0) / 90.0_f64).sqrt()))
+    let distances_row: Vec<f64> = (0..90)
+        .map(|i| (20.0 + 100.0 * (i as f64 + 1.0) / 90.0_f64).sqrt())
         .collect();
-    let mut p_values_row: Vec<CachePadded<f64>> = vec![CachePadded::new(0.0); 90];
+    let mut p_values_row: Vec<f64> = vec![0.0; 90];
     let perplexity = 30.0;
 
     tsne::search_beta(&mut p_values_row, &distances_row, &perplexity);
@@ -899,7 +897,7 @@ fn search_beta_converges_when_optimal_beta_below_one() {
     // must match the requested perplexity.
     let entropy: f64 = p_values_row
         .iter()
-        .map(|p| **p)
+        .copied()
         .filter(|&p| p > 0.0)
         .map(|p| -p * p.ln())
         .sum();

--- a/src/tsne/mod.rs
+++ b/src/tsne/mod.rs
@@ -6,8 +6,6 @@ use std::{
     ops::{Add, AddAssign, DivAssign, MulAssign, SubAssign},
 };
 
-use crossbeam::utils::CachePadded;
-
 use rayon::{
     iter::{
         IndexedParallelIterator, IntoParallelRefIterator, IntoParallelRefMutIterator,
@@ -49,17 +47,17 @@ pub(super) fn check_perplexity<T: Float + AsPrimitive<usize>>(perplexity: &T, n_
 ///
 /// * `gains` - gains.
 pub(super) fn prepare_buffers<T: Float + Send + Sync>(
-    y: &mut Vec<CachePadded<T>>,
-    dy: &mut Vec<CachePadded<T>>,
-    uy: &mut Vec<CachePadded<T>>,
-    gains: &mut Vec<CachePadded<T>>,
+    y: &mut Vec<T>,
+    dy: &mut Vec<T>,
+    uy: &mut Vec<T>,
+    gains: &mut Vec<T>,
     grad_entries: usize,
 ) {
     // Prepares the buffers.
-    y.resize(grad_entries, T::zero().into()); // Embeddings.
-    dy.resize(grad_entries, T::zero().into()); // Gradient.
-    uy.resize(grad_entries, T::zero().into()); // Momentum buffer.
-    gains.resize(grad_entries, T::one().into()); // Gains.
+    y.resize(grad_entries, T::zero()); // Embeddings.
+    dy.resize(grad_entries, T::zero()); // Gradient.
+    uy.resize(grad_entries, T::zero()); // Momentum buffer.
+    gains.resize(grad_entries, T::one()); // Gains.
 }
 
 /// Empties the buffers after the termination of the algorithm. Frees memory allocated by
@@ -75,9 +73,9 @@ pub(super) fn prepare_buffers<T: Float + Send + Sync>(
 ///
 /// * `gains` - gains.
 pub(super) fn clear_buffers<T: Float + Send + Sync>(
-    dy: &mut Vec<CachePadded<T>>,
-    uy: &mut Vec<CachePadded<T>>,
-    gains: &mut Vec<CachePadded<T>>,
+    dy: &mut Vec<T>,
+    uy: &mut Vec<T>,
+    gains: &mut Vec<T>,
 ) {
     // Empties the buffers.
     *dy = Vec::new(); // Gradient.
@@ -120,11 +118,11 @@ pub(super) fn make_rng() -> impl rand::Rng {
 /// # Arguments
 ///
 /// `y` - embedding.
-pub(super) fn random_init<T: Float + Send + Sync + Copy>(y: &mut [CachePadded<T>]) {
+pub(super) fn random_init<T: Float + Send + Sync + Copy>(y: &mut [T]) {
     let distr = Normal::new(0.0, 1e-4).unwrap();
     let mut rng = make_rng();
     y.iter_mut()
-        .for_each(|el| **el = T::from(distr.sample(&mut rng)).unwrap());
+        .for_each(|el| *el = T::from(distr.sample(&mut rng)).unwrap());
 }
 
 /// Computes a squared distance matrix. Computes only the upper triangular entries, excluding the
@@ -140,7 +138,7 @@ pub(super) fn random_init<T: Float + Send + Sync + Copy>(y: &mut [CachePadded<T>
 ///
 /// * `n_samples` - total number of samples.
 pub(super) fn compute_pairwise_distance_matrix<'a, T, U, F, G>(
-    distances: &mut [CachePadded<T>],
+    distances: &mut [T],
     f: F,
     g: G,
     n_samples: usize,
@@ -162,7 +160,7 @@ pub(super) fn compute_pairwise_distance_matrix<'a, T, U, F, G>(
         })
         .filter(|(row_index, column_index, _)| row_index < column_index)
         .for_each(|(i, j, d)| {
-            **d = f(g(&i), g(&j));
+            *d = f(g(&i), g(&j));
         });
 
     // Symmetrizes the matrix. Effectively filling it.
@@ -183,11 +181,8 @@ pub(super) fn compute_pairwise_distance_matrix<'a, T, U, F, G>(
 /// * `distances_row` - row of the distance matrix relative to the sample.
 ///
 /// * `perplexity` - given perplexity value.
-pub(super) fn search_beta<T>(
-    p_values_row: &mut [CachePadded<T>],
-    distances_row: &[CachePadded<T>],
-    perplexity: &T,
-) where
+pub(super) fn search_beta<T>(p_values_row: &mut [T], distances_row: &[T], perplexity: &T)
+where
     T: Send + Sync + Copy + Float + Sum + MulAssign + DivAssign,
 {
     let mut found = false;
@@ -208,18 +203,18 @@ pub(super) fn search_beta<T>(
             .iter_mut()
             .zip(distances_row.iter())
             .for_each(|(p, d)| {
-                **p = (-beta * d.powi(2)).exp();
+                *p = (-beta * d.powi(2)).exp();
             });
 
         // After that the row is normalized.
-        p_values_row_sum = p_values_row.iter().map(|el| **el).sum::<T>() + T::min_positive_value();
+        p_values_row_sum = p_values_row.iter().copied().sum::<T>() + T::min_positive_value();
 
         // The conditional distribution's entropy is needed to find the optimal value
         // for beta, i.e. the bandwidth of the Gaussian kernel.
         let mut entropy = p_values_row
             .iter()
             .zip(distances_row.iter())
-            .fold(T::zero(), |acc, (p, d)| acc + beta * **p * d.powi(2));
+            .fold(T::zero(), |acc, (p, d)| acc + beta * *p * d.powi(2));
         entropy = entropy / p_values_row_sum + p_values_row_sum.ln();
 
         // It evaluates whether the entropy is within the tolerance level.
@@ -259,7 +254,7 @@ pub(super) fn search_beta<T>(
     // Row normalization.
     p_values_row
         .iter_mut()
-        .for_each(|p| **p /= p_values_row_sum + T::epsilon());
+        .for_each(|p| *p /= p_values_row_sum + T::epsilon());
 }
 
 /// Normalizes the P values.
@@ -268,13 +263,13 @@ pub(super) fn search_beta<T>(
 ///
 /// `p_values` - values of the P distribution.
 pub(super) fn normalize_p_values<T: Float + Send + Sync + MulAssign + DivAssign + Sum>(
-    p_values: &mut [CachePadded<T>],
+    p_values: &mut [T],
 ) {
-    let p_values_sum: T = p_values.par_iter().map(|p| **p).sum();
+    let p_values_sum: T = p_values.par_iter().map(|p| *p).sum();
     let twelve = T::from(12.0).unwrap();
     p_values.par_iter_mut().for_each(|p| {
-        **p /= p_values_sum + T::epsilon();
-        **p *= twelve;
+        *p /= p_values_sum + T::epsilon();
+        *p *= twelve;
     });
 }
 
@@ -292,8 +287,8 @@ pub(super) fn normalize_p_values<T: Float + Send + Sync + MulAssign + DivAssign 
 pub(super) fn symmetrize_sparse_matrix<T>(
     sym_p_rows: &mut Vec<usize>,
     sym_p_columns: &mut Vec<usize>,
-    p_columns: Vec<CachePadded<usize>>,
-    p_values: &mut Vec<CachePadded<T>>,
+    p_columns: Vec<usize>,
+    p_values: &mut Vec<T>,
     n_samples: usize,
     n_neighbors: &usize,
 ) where
@@ -311,11 +306,8 @@ pub(super) fn symmetrize_sparse_matrix<T>(
     for n in 0..n_samples {
         for i in p_rows(n)..p_rows(n + 1) {
             row_counts[n] += 1;
-            if !p_columns[p_rows(*p_columns[i])..p_rows(*p_columns[i] + 1)]
-                .iter()
-                .any(|el| **el == n)
-            {
-                row_counts[*p_columns[i]] += 1;
+            if !p_columns[p_rows(p_columns[i])..p_rows(p_columns[i] + 1)].contains(&n) {
+                row_counts[p_columns[i]] += 1;
             }
         }
     }
@@ -324,7 +316,7 @@ pub(super) fn symmetrize_sparse_matrix<T>(
 
     let mut sym_row_p: Vec<usize> = vec![0; n_samples + 1];
     let mut sym_col_p: Vec<usize> = vec![0; total];
-    let mut sym_val_p: Vec<CachePadded<T>> = vec![T::zero().into(); total];
+    let mut sym_val_p: Vec<T> = vec![T::zero(); total];
 
     sym_row_p[0] = 0;
     for _n in 0..n_samples {
@@ -338,31 +330,31 @@ pub(super) fn symmetrize_sparse_matrix<T>(
             // Check whether element (col_P[i], n) is present.
             let mut present: bool = false;
             // Considering element(n, col_P[i]).
-            for m in p_rows(*p_columns[i])..p_rows(*p_columns[i] + 1) {
-                if *p_columns[m] == _n {
+            for m in p_rows(p_columns[i])..p_rows(p_columns[i] + 1) {
+                if p_columns[m] == _n {
                     present = true;
                     // Make sure we do not add elements twice.
-                    if _n <= *p_columns[i] {
-                        sym_col_p[sym_row_p[_n] + offset[_n]] = *p_columns[i];
-                        sym_col_p[sym_row_p[*p_columns[i]] + offset[*p_columns[i]]] = _n;
-                        *sym_val_p[sym_row_p[_n] + offset[_n]] = *p_values[i] + *p_values[m];
-                        *sym_val_p[sym_row_p[*p_columns[i]] + offset[*p_columns[i]]] =
-                            *p_values[i] + *p_values[m];
+                    if _n <= p_columns[i] {
+                        sym_col_p[sym_row_p[_n] + offset[_n]] = p_columns[i];
+                        sym_col_p[sym_row_p[p_columns[i]] + offset[p_columns[i]]] = _n;
+                        sym_val_p[sym_row_p[_n] + offset[_n]] = p_values[i] + p_values[m];
+                        sym_val_p[sym_row_p[p_columns[i]] + offset[p_columns[i]]] =
+                            p_values[i] + p_values[m];
                     }
                 }
             }
             // If (col_P[i], n) is not present, there is no addition involved.
             if !present {
-                sym_col_p[sym_row_p[_n] + offset[_n]] = *p_columns[i];
-                sym_col_p[sym_row_p[*p_columns[i]] + offset[*p_columns[i]]] = _n;
-                *sym_val_p[sym_row_p[_n] + offset[_n]] = *p_values[i];
-                *sym_val_p[sym_row_p[*p_columns[i]] + offset[*p_columns[i]]] = *p_values[i];
+                sym_col_p[sym_row_p[_n] + offset[_n]] = p_columns[i];
+                sym_col_p[sym_row_p[p_columns[i]] + offset[p_columns[i]]] = _n;
+                sym_val_p[sym_row_p[_n] + offset[_n]] = p_values[i];
+                sym_val_p[sym_row_p[p_columns[i]] + offset[p_columns[i]]] = p_values[i];
             }
             // Update offsets.
-            if !present || _n <= *p_columns[i] {
+            if !present || _n <= p_columns[i] {
                 offset[_n] += 1;
-                if *p_columns[i] != _n {
-                    offset[*p_columns[i]] += 1;
+                if p_columns[i] != _n {
+                    offset[p_columns[i]] += 1;
                 }
             }
         }
@@ -370,7 +362,7 @@ pub(super) fn symmetrize_sparse_matrix<T>(
 
     // Divide result by two.
     let zero_point_five = T::from(0.5).unwrap();
-    sym_val_p.iter_mut().for_each(|p| **p *= zero_point_five);
+    sym_val_p.iter_mut().for_each(|p| *p *= zero_point_five);
 
     *p_values = sym_val_p;
     *sym_p_rows = sym_row_p;
@@ -393,10 +385,10 @@ pub(super) fn symmetrize_sparse_matrix<T>(
 ///
 /// * `momentum` - momentum coefficient.
 pub(super) fn update_solution<T>(
-    y: &mut [CachePadded<T>],
-    dy: &[CachePadded<T>],
-    uy: &mut [CachePadded<T>],
-    gains: &mut [CachePadded<T>],
+    y: &mut [T],
+    dy: &[T],
+    uy: &mut [T],
+    gains: &mut [T],
     learning_rate: &T,
     momentum: &T,
 ) where
@@ -411,16 +403,16 @@ pub(super) fn update_solution<T>(
         .zip(uy.par_iter_mut())
         .zip(gains.par_iter_mut())
         .for_each(|(((y_el, dy_el), uy_el), gains_el)| {
-            **gains_el = if dy_el.signum() != uy_el.signum() {
-                **gains_el + zero_point_two
+            *gains_el = if dy_el.signum() != uy_el.signum() {
+                *gains_el + zero_point_two
             } else {
-                **gains_el * zero_point_eight
+                *gains_el * zero_point_eight
             };
-            if **gains_el < zero_point_zero_one {
-                **gains_el = zero_point_zero_one;
+            if *gains_el < zero_point_zero_one {
+                *gains_el = zero_point_zero_one;
             }
-            **uy_el = *momentum * **uy_el - *learning_rate * **gains_el * **dy_el;
-            **y_el += **uy_el
+            *uy_el = *momentum * *uy_el - *learning_rate * *gains_el * *dy_el;
+            *y_el += *uy_el
         });
 }
 
@@ -429,9 +421,9 @@ pub(super) fn update_solution<T>(
 /// # Arguments
 ///
 /// `p_values` - P distribution.
-pub(super) fn stop_lying<T: Float + Send + Sync + DivAssign>(p_values: &mut [CachePadded<T>]) {
+pub(super) fn stop_lying<T: Float + Send + Sync + DivAssign>(p_values: &mut [T]) {
     let twelve = T::from(12.0).unwrap();
-    p_values.par_iter_mut().for_each(|p| **p /= twelve);
+    p_values.par_iter_mut().for_each(|p| *p /= twelve);
 }
 
 /// Makes the solution zero mean. The embedded samples are taken in chunks of size
@@ -449,12 +441,8 @@ pub(super) fn stop_lying<T: Float + Send + Sync + DivAssign>(p_values: &mut [Cac
 /// * `n_samples` -  number of samples in the embedding.
 ///
 /// * `embedding_dim`- dimensionality of the embedding space.
-pub(super) fn zero_mean<T>(
-    means: &mut [T],
-    y: &mut [CachePadded<T>],
-    n_samples: usize,
-    embedding_dim: usize,
-) where
+pub(super) fn zero_mean<T>(means: &mut [T], y: &mut [T], n_samples: usize, embedding_dim: usize)
+where
     T: Float + Send + Sync + Copy + AddAssign + DivAssign + SubAssign,
 {
     // Not parallel as it accumulates into means.
@@ -462,7 +450,7 @@ pub(super) fn zero_mean<T>(
         means
             .iter_mut()
             .zip(embedded_sample.iter())
-            .for_each(|(mean, el)| *mean += **el);
+            .for_each(|(mean, el)| *mean += *el);
     });
 
     let n_samples = T::from(n_samples).unwrap();
@@ -472,7 +460,7 @@ pub(super) fn zero_mean<T>(
         embedded_sample
             .iter_mut()
             .zip(means.iter())
-            .for_each(|(el, mean)| **el -= *mean);
+            .for_each(|(el, mean)| *el -= *mean);
     });
 
     // Zeroes the mean buffer.
@@ -491,35 +479,35 @@ pub(super) fn zero_mean<T>(
 ///
 /// * `embedding_dim` - dimensionality of the embedding space.
 pub(crate) fn evaluate_error<T>(
-    p_values: &[CachePadded<T>],
-    y: &[CachePadded<T>],
+    p_values: &[T],
+    y: &[T],
     n_samples: usize,
     embedding_dim: usize,
 ) -> T
 where
     T: Float + Send + Sync + AddAssign + Add + DivAssign + Sum,
 {
-    let mut distances: Vec<CachePadded<T>> = vec![T::zero().into(); n_samples * n_samples];
+    let mut distances: Vec<T> = vec![T::zero(); n_samples * n_samples];
     compute_pairwise_distance_matrix(
         &mut distances,
-        |a: &[CachePadded<T>], b: &[CachePadded<T>]| {
+        |a: &[T], b: &[T]| {
             a.iter()
                 .zip(b.iter())
-                .map(|(aa, bb)| (**aa - **bb).powi(2))
+                .map(|(aa, bb)| (*aa - *bb).powi(2))
                 .sum::<T>()
         },
         |i| &y[i * embedding_dim..(i + 1) * embedding_dim],
         n_samples,
     );
 
-    let mut q_values: Vec<CachePadded<T>> = vec![T::zero().into(); n_samples * n_samples];
+    let mut q_values: Vec<T> = vec![T::zero(); n_samples * n_samples];
     q_values
         .par_iter_mut()
         .zip(distances.par_iter())
-        .for_each(|(q, d)| **q = T::one() / (T::one() + **d));
+        .for_each(|(q, d)| *q = T::one() / (T::one() + *d));
 
-    let q_sum = q_values.par_iter().map(|q| **q).sum::<T>();
-    q_values.par_iter_mut().for_each(|q| **q /= q_sum);
+    let q_sum = q_values.par_iter().map(|q| *q).sum::<T>();
+    q_values.par_iter_mut().for_each(|q| *q /= q_sum);
 
     // Kullback-Leibler divergence.
     p_values
@@ -528,7 +516,7 @@ where
         .fold(
             || T::zero(),
             |c, (p, q)| {
-                c + **p * ((**p + T::min_positive_value()) / (**q + T::min_positive_value())).ln()
+                c + *p * ((*p + T::min_positive_value()) / (*q + T::min_positive_value())).ln()
             },
         )
         .sum::<T>()
@@ -554,8 +542,8 @@ where
 pub(crate) fn evaluate_error_approximately<T>(
     p_rows: &[usize],
     p_columns: &[usize],
-    p_values: &[CachePadded<T>],
-    y: &[CachePadded<T>],
+    p_values: &[T],
+    y: &[T],
     n_samples: usize,
     embedding_dim: usize,
     theta: T,
@@ -566,11 +554,10 @@ where
     // Get estimate of normalization term.
     let q_sum = {
         let tree = sptree::SPTree::new(embedding_dim, y, n_samples);
-        let mut q_sums: Vec<CachePadded<T>> = vec![T::zero().into(); n_samples];
+        let mut q_sums: Vec<T> = vec![T::zero(); n_samples];
 
-        let mut buffer: Vec<CachePadded<T>> = vec![T::zero().into(); n_samples * embedding_dim];
-        let mut negative_forces: Vec<CachePadded<T>> =
-            vec![T::zero().into(); n_samples * embedding_dim];
+        let mut buffer: Vec<T> = vec![T::zero(); n_samples * embedding_dim];
+        let mut negative_forces: Vec<T> = vec![T::zero(); n_samples * embedding_dim];
 
         q_sums
             .par_iter_mut()
@@ -581,10 +568,10 @@ where
                 tree.compute_non_edge_forces(index, theta, negative_forces_row, buffer_row, sum);
             });
 
-        q_sums.par_iter().map(|sum| **sum).sum::<T>()
+        q_sums.par_iter().map(|sum| *sum).sum::<T>()
     };
 
-    let mut partials: Vec<CachePadded<T>> = vec![T::zero().into(); n_samples];
+    let mut partials: Vec<T> = vec![T::zero(); n_samples];
 
     partials
         .par_iter_mut()
@@ -597,17 +584,16 @@ where
                 let mut q = sample_a
                     .iter()
                     .zip(sample_b.iter())
-                    .map(|(a, b)| (**a - **b).powi(2))
+                    .map(|(a, b)| (*a - *b).powi(2))
                     .sum::<T>();
                 q = (T::one() / (T::one() + q)) / q_sum;
 
                 // Kullback-Leibler divergence.
-                **cost += *p_values[index]
-                    * ((*p_values[index] + T::min_positive_value())
-                        / (q + T::min_positive_value()))
-                    .ln();
+                *cost += p_values[index]
+                    * ((p_values[index] + T::min_positive_value()) / (q + T::min_positive_value()))
+                        .ln();
             }
         });
 
-    partials.par_iter().map(|partial| **partial).sum::<T>()
+    partials.par_iter().map(|partial| *partial).sum::<T>()
 }

--- a/src/tsne/sptree.rs
+++ b/src/tsne/sptree.rs
@@ -5,8 +5,6 @@ use std::{
 
 use num_traits::{Float, NumCast};
 
-use crossbeam::utils::CachePadded;
-
 /// A cell for the SPTree.
 struct SPTreeCell<T: Float + Send + Sync> {
     corner: Vec<T>,
@@ -30,7 +28,7 @@ impl<T: Float + Send + Sync> SPTreeCell<T> {
     /// # Arguments
     ///
     /// `point` - a point.
-    fn contains_point(&self, point: &[CachePadded<T>]) -> bool {
+    fn contains_point(&self, point: &[T]) -> bool {
         debug_assert_eq!(point.len(), self.corner.len());
         debug_assert_eq!(point.len(), self.width.len());
 
@@ -39,7 +37,7 @@ impl<T: Float + Send + Sync> SPTreeCell<T> {
             .iter()
             .zip(self.corner.iter())
             .zip(self.width.iter())
-            .any(|((p, &c), &w)| c - w > **p || c + w < **p)
+            .any(|((p, &c), &w)| c - w > *p || c + w < *p)
     }
 }
 
@@ -52,7 +50,7 @@ where
     is_leaf: bool,
     cumulative_size: i64,
     boundary: SPTreeCell<T>,
-    data: &'a [CachePadded<T>],
+    data: &'a [T],
     center_of_mass: Vec<T>,
     index: Option<usize>,
     children: Vec<SPTree<'a, T>>,
@@ -72,7 +70,7 @@ where
     /// * `data` - data to build the tree from.
     ///
     /// * `n_samples` - number of points in `inp_data`.
-    pub(crate) fn new(dimension: usize, data: &'a [CachePadded<T>], n_samples: usize) -> Self {
+    pub(crate) fn new(dimension: usize, data: &'a [T], n_samples: usize) -> Self {
         // Mean for each dimension.
         let mut mean: Vec<T> = vec![T::zero(); dimension];
         // Min for each dimension.
@@ -87,9 +85,9 @@ where
                 .zip(min.iter_mut())
                 .zip(max.iter_mut())
                 .for_each(|(((s, mean_d), min_d), max_d)| {
-                    *mean_d += **s;
-                    *min_d = min_d.min(**s);
-                    *max_d = max_d.max(**s);
+                    *mean_d += *s;
+                    *min_d = min_d.min(*s);
+                    *max_d = max_d.max(*s);
                 })
         });
 
@@ -124,12 +122,7 @@ where
     /// * `corner` - a corner for a cell.
     ///
     /// * `width` - cell's width.
-    fn new_empty(
-        dimension: usize,
-        data: &'a [CachePadded<T>],
-        corner: Vec<T>,
-        width: Vec<T>,
-    ) -> Self {
+    fn new_empty(dimension: usize, data: &'a [T], corner: Vec<T>, width: Vec<T>) -> Self {
         let n_children = 2usize.pow(dimension as u32);
         let boundary = SPTreeCell::new(corner, width);
         let children = Vec::new();
@@ -175,7 +168,7 @@ where
                 .zip(point.iter())
                 .for_each(|(cm, &p)| {
                     *cm *= m1;
-                    *cm += m2 * *p;
+                    *cm += m2 * p;
                 });
 
             // If there is space in this quad tree and it is a leaf, add the object here.
@@ -192,7 +185,7 @@ where
                             self.data[present * self.dimension..(present + 1) * self.dimension]
                                 .iter(),
                         )
-                        .any(|(&pa, &pb)| (*pa - *pb).abs() >= T::min_positive_value())
+                        .any(|(&pa, &pb)| (pa - pb).abs() >= T::min_positive_value())
                 } else {
                     false
                 };
@@ -299,9 +292,9 @@ where
         &self,
         index: usize,
         theta: T,
-        negative_forces_row: &mut [CachePadded<T>],
-        forces_buffer: &mut [CachePadded<T>],
-        q_sum: &mut CachePadded<T>,
+        negative_forces_row: &mut [T],
+        forces_buffer: &mut [T],
+        q_sum: &mut T,
     ) {
         // Make sure that  no time is spent on empty nodes or self-interactions.
         if self.cumulative_size == 0
@@ -313,15 +306,14 @@ where
         debug_assert_eq!(negative_forces_row.len(), forces_buffer.len());
 
         // Retrieves point slice.
-        let point: &[CachePadded<T>] =
-            &self.data[index * self.dimension..(index + 1) * self.dimension];
+        let point: &[T] = &self.data[index * self.dimension..(index + 1) * self.dimension];
 
         // Compute distance between point and center-of-mass.
         forces_buffer
             .iter_mut()
             .zip(point.iter())
             .zip(self.center_of_mass.iter())
-            .for_each(|((fb, &p), cm)| **fb = *p - *cm);
+            .for_each(|((fb, &p), cm)| *fb = p - *cm);
 
         let mut distance: T = forces_buffer.iter().map(|b| b.powi(2)).sum();
 
@@ -338,13 +330,13 @@ where
 
             let mut m: T = T::from(self.cumulative_size).unwrap() * distance;
 
-            **q_sum += m;
+            *q_sum += m;
             m *= distance;
 
             negative_forces_row
                 .iter_mut()
                 .zip(forces_buffer.iter())
-                .for_each(|(nf, b)| **nf += m * **b);
+                .for_each(|(nf, b)| *nf += m * *b);
         } else {
             // Recursively apply Barnes-Hut to children.
             self.children.iter().for_each(|child| {
@@ -380,12 +372,12 @@ where
     pub(crate) fn compute_edge_forces(
         &self,
         index: usize,
-        sample: &[CachePadded<T>],
+        sample: &[T],
         p_rows: &[usize],
         p_columns: &[usize],
-        p_values: &[CachePadded<T>],
-        forces_buffer: &mut [CachePadded<T>],
-        positive_forces_row: &mut [CachePadded<T>],
+        p_values: &[T],
+        forces_buffer: &mut [T],
+        positive_forces_row: &mut [T],
     ) {
         // Indexes neighbors of sample.
         // index is the index of the sample.
@@ -401,16 +393,16 @@ where
                 .iter_mut()
                 .zip(sample.iter())
                 .zip(other_sample.iter())
-                .for_each(|((fb, s), os)| **fb = **s - **os);
+                .for_each(|((fb, s), os)| *fb = *s - *os);
 
             let mut distance = forces_buffer.iter().map(|fb| fb.powi(2)).sum::<T>();
-            distance = *p_values[i] / (distance + T::one());
+            distance = p_values[i] / (distance + T::one());
 
             // Sum positive force.
             positive_forces_row
                 .iter_mut()
                 .zip(forces_buffer.iter())
-                .for_each(|(pfr, fb)| **pfr += distance * **fb);
+                .for_each(|(pfr, fb)| *pfr += distance * *fb);
         }
     }
 }

--- a/src/tsne/vptree.rs
+++ b/src/tsne/vptree.rs
@@ -4,8 +4,6 @@ use rand::Rng;
 
 use num_traits::Float;
 
-use crossbeam::utils::CachePadded;
-
 /// A node of the vantage point tree.
 #[derive(Clone, Debug)]
 pub(crate) struct Node<T: Float> {
@@ -250,8 +248,8 @@ impl<'a, T: Float + Send + Sync, U> VPTree<'a, T, U> {
         target: &U,
         target_index: usize,
         k: usize,
-        neighbors_indices: &mut [CachePadded<usize>],
-        distances: &mut [CachePadded<T>],
+        neighbors_indices: &mut [usize],
+        distances: &mut [T],
         metric_f: F,
     ) where
         F: Fn(&U, &U) -> T,
@@ -275,8 +273,8 @@ impl<'a, T: Float + Send + Sync, U> VPTree<'a, T, U> {
             }))
             .for_each(|((idx, d), result)| {
                 let HeapItem { index, distance } = result;
-                **idx = *index;
-                **d = *distance;
+                *idx = *index;
+                *d = *distance;
             });
     }
 }


### PR DESCRIPTION
This makes the t-SNE optimization loop faster without changing its output. Each working buffer (the embedding, gradient, gains, and the `P` and `Q` matrices) was a `Vec<CachePadded<T>>`, so every `f32` sat on its own 128 byte cache line, a 32x memory blowup that ruined cache locality and blocked vectorization. Storing them as plain `Vec<T>` makes the exact gradient loop about 5x faster and the full Barnes-Hut fit about 1.15x faster, for both `f32` and `f64`, with bitwise identical embeddings (checked with a fixed seed on both paths).

The Barnes-Hut force loop also accumulates each sample's forces in thread-local scratch and writes them once, to avoid false sharing on the now dense per-sample outputs. The PR adds a `criterion` benchmark of the loop and drops the `crossbeam` dependency, which existed only for `CachePadded`.