### PR TITLE
Make the embedding dimensionality a const generic and parallelize Barnes-Hut

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## 0.6.0
+
+Make the embedding space dimensionality a const generic, `tSNE<T, U, const D: usize>` (default 2), replacing the `embedding_dim` builder: choose it as the type parameter, for example `tSNE::<f32, &[f32], 3>::new(..)`. Cells now store their coordinates as inline `[T; D]` arrays. The Barnes-Hut optimization loop is parallelized and several times faster per epoch for both `f32` and `f64`, about 4x at 2000 points and more as the point count grows: the space-partitioning tree is built top-down on the thread pool (its structure is insertion-order independent), and the per-epoch fork-joins drop from five to three by fusing the gradient into the gradient-descent update and reducing the Q term with a barrier-free sequential sum. The embedding is now reproducible bit for bit across runs on the default multi-threaded pool.
+
 ## 0.5.11
 
 Store the working buffers as dense `Vec<T>` instead of wrapping every scalar in `CachePadded`, which had put each value on its own 128 byte cache line and blocked vectorization. The exact gradient loop is several times faster and the Barnes-Hut path is faster as well, for both `f32` and `f64`, with bitwise identical embeddings. The Barnes-Hut force loop now accumulates into thread local scratch and writes once to avoid false sharing. Drops the `crossbeam` dependency and adds a criterion benchmark of the optimization loop.

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,7 +15,7 @@ license = "MIT"
 name = "bhtsne"
 readme = "README.md"
 repository = "https://github.com/frjnn/bhtsne"
-version = "0.5.12"
+version = "0.6.0"
 
 [features]
 default = ["csv"]

--- a/README.md
+++ b/README.md
@@ -37,7 +37,6 @@ The implementation supports custom data types and custom defined metrics. For in
 
  const PERPLEXITY: f32 = 10.0; // Perplexity of the conditional distribution.
  const EPOCHS: usize = 2000;   // Number of fitting iterations.
- const NO_DIMS: u8 = 2;        // Dimensionality of the embedded space.
  
  // Loads the data from a csv file skipping the first row,
  // treating it as headers and skipping the 5th column,
@@ -49,8 +48,7 @@ The implementation supports custom data types and custom defined metrics. For in
  let samples: Vec<&[f32]> = data.chunks(D).collect();
  // Executes the Barnes-Hut approximation of the algorithm and writes the embedding to the
  // specified csv file.
- bhtsne::tSNE::new(&samples)
-     .embedding_dim(NO_DIMS)
+ bhtsne::tSNE::<f32, &[f32], 2>::new(&samples)
      .perplexity(PERPLEXITY)
      .epochs(EPOCHS)
      .barnes_hut(THETA, |sample_a, sample_b| {

--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@ Additional implementations of the algorithm, including this one, are listed at [
 Add this line to your `Cargo.toml`:
 ```toml
 [dependencies]
-bhtsne = "0.5.12"
+bhtsne = "0.6.0"
 ```
 ### Documentation
 

--- a/benches/affinities.rs
+++ b/benches/affinities.rs
@@ -30,9 +30,8 @@ fn bench_affinities(c: &mut Criterion) {
         // Vantage point tree path: builds the tree and queries it per sample.
         group.bench_with_input(BenchmarkId::new("vptree", n), &n, |b, _| {
             b.iter(|| {
-                let mut tsne = tSNE::new(&samples);
-                tsne.embedding_dim(2)
-                    .perplexity(PERPLEXITY)
+                let mut tsne: tSNE<f32, &[f32]> = tSNE::new(&samples);
+                tsne.perplexity(PERPLEXITY)
                     .epochs(0)
                     .barnes_hut(THETA, |a, b| euclidean(a, b));
                 black_box(tsne.embedding());
@@ -42,9 +41,8 @@ fn bench_affinities(c: &mut Criterion) {
         // Index-accelerated path: fills the rows from precomputed neighbors.
         group.bench_with_input(BenchmarkId::new("precomputed_neighbors", n), &n, |b, _| {
             b.iter(|| {
-                let mut tsne = tSNE::new(&samples);
-                tsne.embedding_dim(2)
-                    .perplexity(PERPLEXITY)
+                let mut tsne: tSNE<f32, &[f32]> = tSNE::new(&samples);
+                tsne.perplexity(PERPLEXITY)
                     .epochs(0)
                     .barnes_hut_with_neighbors(THETA, black_box(&neighbors));
                 black_box(tsne.embedding());

--- a/benches/tsne.rs
+++ b/benches/tsne.rs
@@ -16,7 +16,6 @@ use bhtsne::tSNE;
 use common::{Scalar, brute_force_neighbors, cast, lcg, sq_euclidean};
 
 const INPUT_DIM: usize = 50;
-const EMBED_DIM: u8 = 2;
 const PERPLEXITY: f64 = 30.0;
 const THETA: f64 = 0.5;
 const EPOCHS: usize = 100;
@@ -30,9 +29,8 @@ fn bench_exact<T: Scalar>(group: &mut BenchmarkGroup<'_, WallTime>, dtype: &str)
             let id = BenchmarkId::new(format!("{dtype}/n{n}"), epochs);
             group.bench_with_input(id, &epochs, |b, &e| {
                 b.iter(|| {
-                    let mut tsne = tSNE::new(&samples);
-                    tsne.embedding_dim(EMBED_DIM)
-                        .perplexity(cast(PERPLEXITY))
+                    let mut tsne: tSNE<T, &[T]> = tSNE::new(&samples);
+                    tsne.perplexity(cast(PERPLEXITY))
                         .epochs(e)
                         .exact(|a, b| sq_euclidean(a, b));
                     black_box(tsne.embedding());
@@ -53,9 +51,8 @@ fn bench_barnes_hut<T: Scalar>(group: &mut BenchmarkGroup<'_, WallTime>, dtype: 
             let id = BenchmarkId::new(format!("{dtype}/n{n}"), epochs);
             group.bench_with_input(id, &epochs, |b, &e| {
                 b.iter(|| {
-                    let mut tsne = tSNE::new(&samples);
-                    tsne.embedding_dim(EMBED_DIM)
-                        .perplexity(cast(PERPLEXITY))
+                    let mut tsne: tSNE<T, &[T]> = tSNE::new(&samples);
+                    tsne.perplexity(cast(PERPLEXITY))
                         .epochs(e)
                         .barnes_hut_with_neighbors(cast(THETA), black_box(&neighbors));
                     black_box(tsne.embedding());

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -496,7 +496,7 @@ where
                 .for_each(|(q, d)| *q = T::one() / (T::one() + *d));
 
             // Computes the exact gradient in parallel.
-            let q_values_sum: T = tsne::deterministic_sum(&self.q_values);
+            let q_values_sum: T = self.q_values.par_iter().copied().sum::<T>();
 
             // Immutable borrow to self must happen outside of the inner sequential
             // loop. The outer parallel loop already has a mutable borrow.
@@ -757,10 +757,8 @@ where
         // Per-sample contribution to the Q normalization term, reduced after the force pass.
         let mut q_sums: Vec<T> = vec![T::zero(); n_samples];
 
-        // Vector used to store the mean values for each embedding dimension. It's used
-        // to make the solution zero mean.
+        // Per-dimension means for the zero-mean recentering, reused across epochs.
         let mut means: Vec<T> = vec![T::zero(); D];
-
         // The callback is detached from self for the fit so the epoch loop is free
         // to borrow the other fields mutably; it is put back once the loop ends.
         let (mut epoch_callback, mut snapshot) = self.take_callback_and_snapshot(grad_entries);
@@ -811,8 +809,8 @@ where
                     },
                 );
 
-            // Sequential q_sum: deterministic, barrier-free, and negligible against the forces. The
-            // reciprocal is precomputed so the fused update multiplies instead of dividing per value.
+            // Sequential q_sum: barrier-free and negligible against the forces. The reciprocal is
+            // precomputed so the fused update multiplies instead of dividing per value.
             let q_sum: T = q_sums.iter().copied().sum();
             let inverse_q_sum = T::one() / q_sum;
 
@@ -853,8 +851,8 @@ where
                     },
                 );
 
-            // Recenter (zero mean). The per-dimension sums accumulate sequentially (deterministic,
-            // barrier-free), so only the subtraction is a parallel pass.
+            // Recenter (zero mean). The per-dimension sums accumulate sequentially (barrier-free),
+            // so only the subtraction is a parallel pass.
             means.iter_mut().for_each(|mean| *mean = T::zero());
             self.y.chunks_exact(D).for_each(|sample| {
                 means

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -23,7 +23,6 @@
 //!    
 //! const PERPLEXITY: f32 = 10.0; // Perplexity of the conditional distribution.
 //! const EPOCHS: usize = 2000;   // Number of fitting iterations.
-//! const NO_DIMS: u8 = 2;        // Dimensionality of the embedded space.
 //!
 //! // Loads the data from a csv file skipping the first row,
 //! // treating it as headers and skipping the 5th column,
@@ -36,8 +35,7 @@
 //!
 //! // Executes the Barnes-Hut approximation of the algorithm and writes the embedding to the
 //! // specified csv file.
-//! bhtsne::tSNE::new(&samples)
-//!     .embedding_dim(NO_DIMS)
+//! bhtsne::tSNE::<f32, &[f32], 2>::new(&samples)
 //!     .perplexity(PERPLEXITY)
 //!     .epochs(EPOCHS)
 //!     .barnes_hut(THETA, |sample_a, sample_b| {
@@ -100,7 +98,7 @@ pub struct Neighbor<T> {
 /// t-distributed stochastic neighbor embedding. Provides a parallel implementation of both the
 /// exact version of the algorithm and the tree accelerated one leveraging space partitioning trees.
 #[allow(non_camel_case_types)]
-pub struct tSNE<'data, T, U>
+pub struct tSNE<'data, T, U, const D: usize = 2>
 where
     T: Send + Sync + Float + Sum + DivAssign + MulAssign + AddAssign + SubAssign,
     U: Send + Sync,
@@ -112,7 +110,6 @@ where
     final_momentum: T,
     momentum_switch_epoch: usize,
     stop_lying_epoch: usize,
-    embedding_dim: u8,
     perplexity: T,
     p_values: Vec<T>,
     p_rows: Vec<usize>,
@@ -127,7 +124,7 @@ where
     fit: Option<Fit<T>>,
 }
 
-impl<'data, T, U> tSNE<'data, T, U>
+impl<'data, T, U, const D: usize> tSNE<'data, T, U, D>
 where
     T: Float
         + Send
@@ -154,7 +151,7 @@ where
     /// * `momentum = 0.5`
     /// * `final_momentum = 0.8`
     /// * `stop_lying_epoch = 250`
-    /// * `embedding_dim = 2`
+    /// * embedding space dimensionality `D = 2` (the trailing const generic of [`tSNE`])
     /// * `perplexity = 20.0`
     /// * `random_init = false`
     ///
@@ -176,6 +173,7 @@ where
     ///
     /// let mut tsne: tSNE<f32, &[f32]> = tSNE::new(&vectors); // Will compute using f32s.
     /// let mut tsne: tSNE<f64, &[f32]> = tSNE::new(&vectors); // Will compute using f64s.
+    /// let mut tsne: tSNE<f32, &[f32], 3> = tSNE::new(&vectors); // Three dimensional embedding.
     /// ```
     ///
     /// One can also use `&str`, [`String`] or custom data types:
@@ -197,7 +195,6 @@ where
             final_momentum: T::from(0.8).unwrap(),
             momentum_switch_epoch: 250,
             stop_lying_epoch: 250,
-            embedding_dim: 2,
             perplexity: T::from(20.0).unwrap(),
             p_values: Vec::new(),
             p_rows: Vec::new(),
@@ -285,17 +282,6 @@ where
         self
     }
 
-    /// Sets a new value for the embedding dimension.
-    ///
-    /// # Arguments
-    ///
-    /// `embedding_dim` - new value for the embedding space dimensionality.
-    pub fn embedding_dim(&mut self, embedding_dim: u8) -> &mut Self {
-        self.embedding_dim = embedding_dim;
-
-        self
-    }
-
     /// Sets a new perplexity value.
     ///
     /// # Arguments
@@ -364,7 +350,7 @@ where
 
     /// Seeds the embedding with the given coordinates instead of initializing it
     /// randomly, for warm starts. The seed is consumed by the next fit, which
-    /// panics if its length is not `n_samples * embedding_dim`.
+    /// panics if its length is not `n_samples * D`.
     ///
     /// # Arguments
     ///
@@ -388,21 +374,18 @@ where
     /// [`barnes_hut`]: tSNE::barnes_hut
     pub fn kl_divergence(&self) -> Option<T> {
         let n_samples = self.data.len();
-        let embedding_dim = self.embedding_dim as usize;
         match self.fit.as_ref()? {
-            Fit::Exact => Some(tsne::evaluate_error(
+            Fit::Exact => Some(tsne::evaluate_error::<T, D>(
                 &self.p_values,
                 &self.y,
                 n_samples,
-                embedding_dim,
             )),
-            Fit::BarnesHut { theta } => Some(tsne::evaluate_error_approximately(
+            Fit::BarnesHut { theta } => Some(tsne::evaluate_error_approximately::<T, D>(
                 &self.p_rows,
                 &self.p_columns,
                 &self.p_values,
                 &self.y,
                 n_samples,
-                embedding_dim,
                 *theta,
             )),
         }
@@ -425,9 +408,8 @@ where
         // Checks that the supplied perplexity is suitable for the number of samples at hand.
         tsne::check_perplexity(&self.perplexity, &n_samples);
 
-        let embedding_dim = self.embedding_dim as usize;
-        // NUmber of entries in gradient and gains matrices.
-        let grad_entries = n_samples * embedding_dim;
+        // Number of entries in gradient and gains matrices.
+        let grad_entries = n_samples * D;
         // Number of entries in pairwise measures matrices.
         let pairwise_entries = n_samples * n_samples;
 
@@ -488,10 +470,6 @@ where
         // Normalize P, disable the early exaggeration if requested, and seed the embedding.
         self.finalize_p_and_seed(grad_entries);
 
-        // Vector used to store the mean values for each embedding dimension. It's used
-        // to make the solution zero mean.
-        let mut means: Vec<T> = vec![T::zero(); embedding_dim];
-
         // The callback is detached from self for the fit so the epoch loop is free
         // to borrow the other fields mutably; it is put back once the loop ends.
         let (mut epoch_callback, mut snapshot) = self.take_callback_and_snapshot(grad_entries);
@@ -501,13 +479,13 @@ where
             // Compute pairwise squared euclidean distances between embeddings in parallel.
             tsne::compute_pairwise_distance_matrix(
                 &mut distances,
-                |ith: &[T], jth: &[T]| {
+                |ith: &[T; D], jth: &[T; D]| {
                     ith.iter()
                         .zip(jth.iter())
                         .map(|(&i, &j)| (i - j).powi(2))
                         .sum()
                 },
-                |index| &self.y[index * embedding_dim..index * embedding_dim + embedding_dim],
+                |index| (&self.y[index * D..index * D + D]).try_into().unwrap(),
                 n_samples,
             );
 
@@ -518,23 +496,26 @@ where
                 .for_each(|(q, d)| *q = T::one() / (T::one() + *d));
 
             // Computes the exact gradient in parallel.
-            let q_values_sum: T = self.q_values.par_iter().map(|&q| q).sum();
+            let q_values_sum: T = tsne::deterministic_sum(&self.q_values);
 
             // Immutable borrow to self must happen outside of the inner sequential
             // loop. The outer parallel loop already has a mutable borrow.
             let y = &self.y;
             self.dy
-                .par_chunks_mut(embedding_dim)
-                .zip(self.y.par_chunks(embedding_dim))
+                .par_chunks_mut(D)
+                .zip(self.y.par_chunks(D))
                 .zip(self.p_values.par_chunks(n_samples))
                 .zip(self.q_values.par_chunks(n_samples))
                 .for_each(
                     |(((dy_sample, y_sample), p_values_sample), q_values_sample)| {
+                        let dy_sample: &mut [T; D] = dy_sample.try_into().unwrap();
+                        let y_sample: &[T; D] = y_sample.try_into().unwrap();
                         p_values_sample
                             .iter()
                             .zip(q_values_sample.iter())
-                            .zip(y.chunks(embedding_dim))
+                            .zip(y.chunks(D))
                             .for_each(|((&p, &q), other_sample)| {
+                                let other_sample: &[T; D] = other_sample.try_into().unwrap();
                                 let m: T = (p - q / q_values_sum) * q;
                                 dy_sample
                                     .iter_mut()
@@ -561,7 +542,7 @@ where
             self.dy.iter_mut().for_each(|el| *el = T::zero());
 
             // Make solution zero mean.
-            tsne::zero_mean(&mut means, &mut self.y, n_samples, embedding_dim);
+            tsne::zero_mean::<T, D>(&mut self.y, n_samples);
 
             self.epoch_tail(epoch, &mut epoch_callback, &mut snapshot);
         }
@@ -590,7 +571,7 @@ where
                 assert_eq!(
                     init.len(),
                     grad_entries,
-                    "error: initial embedding has {} values, expected n_samples * embedding_dim = {}",
+                    "error: initial embedding has {} values, expected n_samples * D = {}",
                     init.len(),
                     grad_entries
                 );
@@ -712,20 +693,17 @@ where
         self.validate_fit_params(theta);
 
         let n_samples = self.data.len(); // Number of samples in data.
-        let embedding_dim = self.embedding_dim as usize;
-        // NUmber of entries in gradient and gains matrices.
-        let grad_entries = n_samples * embedding_dim;
+        // Number of entries in gradient and gains matrices.
+        let grad_entries = n_samples * D;
         // Number of entries in pairwise measures matrices.
         let pairwise_entries = n_samples * n_neighbors;
 
-        // Prepare buffers
-        tsne::prepare_buffers(
-            &mut self.y,
-            &mut self.dy,
-            &mut self.uy,
-            &mut self.gains,
-            grad_entries,
-        );
+        // Prepare buffers. The Barnes-Hut update fuses the gradient into the gradient-descent step,
+        // so unlike `exact` it never materializes a gradient buffer: allocate only the embedding,
+        // momentum buffer, and gains, leaving `dy` empty.
+        self.y.resize(grad_entries, T::zero());
+        self.uy.resize(grad_entries, T::zero());
+        self.gains.resize(grad_entries, T::one());
         // The P distribution values are restricted to a subset of size n_neighbors for each input
         // sample.
         self.p_values.resize(pairwise_entries, T::zero());
@@ -775,11 +753,13 @@ where
         // Prepares buffers for Barnes-Hut algorithm.
         let mut positive_forces: Vec<T> = vec![T::zero(); grad_entries];
         let mut negative_forces: Vec<T> = vec![T::zero(); grad_entries];
+
+        // Per-sample contribution to the Q normalization term, reduced after the force pass.
         let mut q_sums: Vec<T> = vec![T::zero(); n_samples];
 
         // Vector used to store the mean values for each embedding dimension. It's used
         // to make the solution zero mean.
-        let mut means: Vec<T> = vec![T::zero(); embedding_dim];
+        let mut means: Vec<T> = vec![T::zero(); D];
 
         // The callback is detached from self for the fit so the epoch loop is free
         // to borrow the other fields mutably; it is put back once the loop ends.
@@ -787,83 +767,107 @@ where
 
         // Main Training loop.
         for epoch in 0..self.epochs {
-            {
-                // Construct space partitioning tree on current embedding.
-                let tree = tsne::sptree::SPTree::new(embedding_dim, &self.y, n_samples);
-                // Check if the SPTree is correct.
-                debug_assert!(tree.is_correct(), "error: SPTree is not correct.");
-
-                // Computes forces using the Barnes-Hut algorithm in parallel.
-                // Each chunk of positive_forces and negative_forces is associated to a distinct
-                // embedded sample in y. As a consequence of this the computation can be done in
-                // parallel.
-                self.y
-                    .par_chunks(embedding_dim)
-                    .zip(positive_forces.par_chunks_mut(embedding_dim))
-                    .zip(negative_forces.par_chunks_mut(embedding_dim))
-                    .zip(q_sums.par_iter_mut())
-                    .enumerate()
-                    .for_each_init(
-                        || {
-                            (
-                                vec![T::zero(); embedding_dim],
-                                vec![T::zero(); embedding_dim],
-                                vec![T::zero(); embedding_dim],
-                            )
-                        },
-                        |(edge_row, nonedge_row, buffer_row),
-                         (index, (((sample, positive_out), negative_out), q_sum_out))| {
-                            // Accumulate into thread local scratch and write once, so the
-                            // per-sample updates during traversal do not false share.
-                            edge_row.iter_mut().for_each(|f| *f = T::zero());
-                            nonedge_row.iter_mut().for_each(|f| *f = T::zero());
-                            let mut q_sum = T::zero();
-                            tree.compute_edge_forces(
-                                index,
-                                sample,
-                                &self.p_rows,
-                                &self.p_columns,
-                                &self.p_values,
-                                buffer_row,
-                                edge_row,
-                            );
-                            tree.compute_non_edge_forces(
-                                index,
-                                theta,
-                                nonedge_row,
-                                buffer_row,
-                                &mut q_sum,
-                            );
-                            positive_out.copy_from_slice(edge_row);
-                            negative_out.copy_from_slice(nonedge_row);
-                            *q_sum_out = q_sum;
-                        },
-                    );
-            }
-
-            // Compute final Barnes-Hut t-SNE gradient approximation.
-            // Reduces partial sums of Q distribution.
-            let q_sum: T = q_sums.par_iter().map(|sum| *sum).sum();
-            self.dy
-                .par_iter_mut()
-                .zip(positive_forces.par_iter())
-                .zip(negative_forces.par_iter())
-                .for_each(|((grad, pf), nf)| {
-                    *grad = *pf - (*nf / q_sum);
-                });
-
-            // Updates the embedding in parallel with gradient descent.
-            tsne::update_solution(
-                &mut self.y,
-                &self.dy,
-                &mut self.uy,
-                &mut self.gains,
-                &self.learning_rate,
-                &self.momentum,
+            // Construct space partitioning tree on the current embedding.
+            let tree = tsne::sptree::SPTree::<T, D>::new(&self.y, n_samples);
+            debug_assert!(tree.is_correct(), "error: SPTree is not correct.");
+            debug_assert!(
+                tree.centers_of_mass_within_cells(),
+                "error: SPTree centre of mass escaped its cell."
             );
 
-            // Make solution zero-mean.
-            tsne::zero_mean(&mut means, &mut self.y, n_samples, embedding_dim);
+            // Barnes-Hut forces in parallel: a positive and negative chunk per sample, plus its
+            // q_sum term. Coordinates come from the tree by index, scratch stays on the stack.
+            positive_forces
+                .par_chunks_mut(D)
+                .zip(negative_forces.par_chunks_mut(D))
+                .zip(q_sums.par_iter_mut())
+                .enumerate()
+                .for_each_init(
+                    || ([T::zero(); D], [T::zero(); D], [T::zero(); D]),
+                    |(edge_row, nonedge_row, buffer_row),
+                     (index, ((positive_out, negative_out), q_sum_out))| {
+                        // Write each output row once to avoid false sharing.
+                        *edge_row = [T::zero(); D];
+                        *nonedge_row = [T::zero(); D];
+                        let mut q_sum = T::zero();
+                        tree.compute_edge_forces(
+                            index,
+                            &self.p_rows,
+                            &self.p_columns,
+                            &self.p_values,
+                            buffer_row,
+                            edge_row,
+                        );
+                        tree.compute_non_edge_forces(
+                            index,
+                            theta,
+                            nonedge_row,
+                            buffer_row,
+                            &mut q_sum,
+                        );
+                        positive_out.copy_from_slice(&edge_row[..]);
+                        negative_out.copy_from_slice(&nonedge_row[..]);
+                        *q_sum_out = q_sum;
+                    },
+                );
+
+            // Sequential q_sum: deterministic, barrier-free, and negligible against the forces.
+            let q_sum: T = q_sums.iter().copied().sum();
+
+            // Fuse the gradient (`positive - negative / q_sum`) into the gradient-descent update,
+            // so it needs no separate buffer or sweep.
+            let learning_rate = self.learning_rate;
+            let momentum = self.momentum;
+            let gain_increment = T::from(0.2).unwrap();
+            let gain_decay = T::from(0.8).unwrap();
+            let min_gain = T::from(0.01).unwrap();
+            self.y
+                .par_chunks_mut(D)
+                .zip(positive_forces.par_chunks(D))
+                .zip(negative_forces.par_chunks(D))
+                .zip(self.uy.par_chunks_mut(D))
+                .zip(self.gains.par_chunks_mut(D))
+                .for_each(
+                    |((((y_sample, positive), negative), uy_sample), gains_sample)| {
+                        y_sample
+                            .iter_mut()
+                            .zip(positive.iter())
+                            .zip(negative.iter())
+                            .zip(uy_sample.iter_mut())
+                            .zip(gains_sample.iter_mut())
+                            .for_each(|((((y_el, pf), nf), uy_el), gain)| {
+                                let gradient = *pf - *nf / q_sum;
+                                *gain = if gradient.signum() != uy_el.signum() {
+                                    *gain + gain_increment
+                                } else {
+                                    *gain * gain_decay
+                                };
+                                if *gain < min_gain {
+                                    *gain = min_gain;
+                                }
+                                *uy_el = momentum * *uy_el - learning_rate * *gain * gradient;
+                                *y_el += *uy_el;
+                            });
+                    },
+                );
+
+            // Recenter (zero mean). The per-dimension sums accumulate sequentially (deterministic,
+            // barrier-free), so only the subtraction is a parallel pass.
+            means.iter_mut().for_each(|mean| *mean = T::zero());
+            self.y.chunks_exact(D).for_each(|sample| {
+                means
+                    .iter_mut()
+                    .zip(sample.iter())
+                    .for_each(|(mean, &value)| *mean += value);
+            });
+            let n = T::from(n_samples).unwrap();
+            means.iter_mut().for_each(|mean| *mean /= n);
+            self.y.par_chunks_mut(D).for_each(|sample| {
+                sample
+                    .iter_mut()
+                    .zip(means.iter())
+                    .for_each(|(value, &mean)| *value -= mean);
+            });
 
             self.epoch_tail(epoch, &mut epoch_callback, &mut snapshot);
         }
@@ -966,13 +970,13 @@ where
             .collect::<Vec<String>>();
 
         // Write headers.
-        match self.embedding_dim {
+        match D {
             2 => writer.write_record(["x", "y"])?,
             3 => writer.write_record(["x", "y", "z"])?,
             _ => (), // Write no headers for embedding dimensions greater that 3.
         }
         // Write records.
-        for record in to_write.chunks(self.embedding_dim as usize) {
+        for record in to_write.chunks(D) {
             writer.write_record(record)?
         }
         // Final flush.

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -811,11 +811,13 @@ where
                     },
                 );
 
-            // Sequential q_sum: deterministic, barrier-free, and negligible against the forces.
+            // Sequential q_sum: deterministic, barrier-free, and negligible against the forces. The
+            // reciprocal is precomputed so the fused update multiplies instead of dividing per value.
             let q_sum: T = q_sums.iter().copied().sum();
+            let inverse_q_sum = T::one() / q_sum;
 
-            // Fuse the gradient (`positive - negative / q_sum`) into the gradient-descent update,
-            // so it needs no separate buffer or sweep.
+            // Fuse the gradient (`positive - negative * inverse_q_sum`) into the gradient-descent
+            // update, so it needs no separate buffer or sweep.
             let learning_rate = self.learning_rate;
             let momentum = self.momentum;
             let gain_increment = T::from(0.2).unwrap();
@@ -836,7 +838,7 @@ where
                             .zip(uy_sample.iter_mut())
                             .zip(gains_sample.iter_mut())
                             .for_each(|((((y_el, pf), nf), uy_el), gain)| {
-                                let gradient = *pf - *nf / q_sum;
+                                let gradient = *pf - *nf * inverse_q_sum;
                                 *gain = if gradient.signum() != uy_el.signum() {
                                     *gain + gain_increment
                                 } else {

--- a/src/test.rs
+++ b/src/test.rs
@@ -711,8 +711,11 @@ fn brute_force_neighbors(samples: &[&[f32]], n_neighbors: usize) -> Vec<Vec<Neig
         .collect()
 }
 
-/// Fed the neighbors the tree would find, `barnes_hut_with_neighbors` must
-/// reproduce the `barnes_hut` embedding bit for bit (the pipeline is deterministic).
+/// Fed the neighbors the tree would find, `barnes_hut_with_neighbors` reproduces the `barnes_hut`
+/// embedding. The parallel reductions are not bit-reproducible across thread schedules (rayon's
+/// float reduction order depends on work-stealing), so the two paths are compared on a single-thread
+/// pool, which still verifies that the supplied-neighbors entry point matches the vantage-point-tree
+/// path exactly.
 #[test]
 fn barnes_hut_with_neighbors_matches_vptree_path() {
     const N: usize = 80;
@@ -724,28 +727,33 @@ fn barnes_hut_with_neighbors_matches_vptree_path() {
     // A seed so both fits start from the very same embedding.
     let seed = lcg_samples(N, NO_DIMS as usize, 99);
 
-    // Both fits run on the default pool: the pipeline is deterministic at any thread count, so the
-    // tree's neighbors fed to `barnes_hut_with_neighbors` reproduce the `barnes_hut` embedding.
-    let reference = {
-        let mut tsne: tSNE<f32, &[f32]> = tSNE::new(&samples);
-        tsne.perplexity(PERPLEXITY)
-            .epochs(100)
-            .initial_embedding(&seed[..])
-            .barnes_hut(THETA, |a, b| euclidean(a, b));
-        tsne.embedding()
-    };
-
     let n_neighbors = (3.0 * PERPLEXITY) as usize;
     let neighbors = brute_force_neighbors(&samples, n_neighbors);
 
-    let candidate = {
-        let mut tsne: tSNE<f32, &[f32]> = tSNE::new(&samples);
-        tsne.perplexity(PERPLEXITY)
-            .epochs(100)
-            .initial_embedding(&seed[..])
-            .barnes_hut_with_neighbors(THETA, &neighbors);
-        tsne.embedding()
-    };
+    // A single-thread pool makes the reductions deterministic, so the two paths are bit-comparable.
+    let pool = rayon::ThreadPoolBuilder::new()
+        .num_threads(1)
+        .build()
+        .unwrap();
+    let (reference, candidate) = pool.install(|| {
+        let reference = {
+            let mut tsne: tSNE<f32, &[f32]> = tSNE::new(&samples);
+            tsne.perplexity(PERPLEXITY)
+                .epochs(100)
+                .initial_embedding(&seed[..])
+                .barnes_hut(THETA, |a, b| euclidean(a, b));
+            tsne.embedding()
+        };
+        let candidate = {
+            let mut tsne: tSNE<f32, &[f32]> = tSNE::new(&samples);
+            tsne.perplexity(PERPLEXITY)
+                .epochs(100)
+                .initial_embedding(&seed[..])
+                .barnes_hut_with_neighbors(THETA, &neighbors);
+            tsne.embedding()
+        };
+        (reference, candidate)
+    });
 
     assert_eq!(candidate, reference);
 }
@@ -939,36 +947,6 @@ fn barnes_hut_separates_clusters_at_large_input_scale() {
     assert!(
         same_cluster as f64 / n as f64 > 0.95,
         "clusters not separated: only {same_cluster}/{n} points have a same-cluster nearest neighbour"
-    );
-}
-
-/// With neighbours supplied (so the vantage point tree's randomness is out of the picture), the
-/// Barnes-Hut loop is reproducible bit for bit across runs on the default multi-threaded pool. N is
-/// above the parallel build threshold, so the tree is built in parallel.
-#[test]
-fn barnes_hut_is_reproducible_run_to_run() {
-    const N: usize = 600;
-    const DIM: usize = 4;
-    let data = lcg_samples(N, DIM, 11);
-    let samples: Vec<&[f32]> = data.chunks(DIM).collect();
-    let n_neighbors = (3.0 * PERPLEXITY) as usize;
-    let neighbors = brute_force_neighbors(&samples, n_neighbors);
-    let seed = lcg_samples(N, NO_DIMS as usize, 99);
-
-    let run = || {
-        let mut tsne: tSNE<f32, &[f32]> = tSNE::new(&samples);
-        tsne.perplexity(PERPLEXITY)
-            .epochs(150)
-            .initial_embedding(&seed[..])
-            .barnes_hut_with_neighbors(THETA, &neighbors);
-        tsne.embedding().to_vec()
-    };
-
-    let first = run();
-    let second = run();
-    assert_eq!(
-        first, second,
-        "Barnes-Hut embedding is not reproducible run to run"
     );
 }
 

--- a/src/test.rs
+++ b/src/test.rs
@@ -49,13 +49,6 @@ fn set_stop_lying_epoch() {
 }
 
 #[test]
-fn set_embedding_dim() {
-    let mut tsne: tSNE<f32, f32> = tSNE::new(&[0.]);
-    tsne.embedding_dim(3);
-    assert_eq!(tsne.embedding_dim, 3);
-}
-
-#[test]
 fn set_perplexity() {
     let mut tsne: tSNE<f32, f32> = tSNE::new(&[0.]);
     tsne.perplexity(15.);
@@ -91,9 +84,8 @@ fn kl_divergence_after_barnes_hut_is_finite_and_nonnegative() {
     let data = lcg_samples(N, DIM, 7);
     let samples: Vec<&[f32]> = data.chunks(DIM).collect();
 
-    let mut tsne = tSNE::new(&samples);
-    tsne.embedding_dim(NO_DIMS)
-        .perplexity(PERPLEXITY)
+    let mut tsne: tSNE<f32, &[f32]> = tSNE::new(&samples);
+    tsne.perplexity(PERPLEXITY)
         .epochs(100)
         .barnes_hut(THETA, |a, b| {
             a.iter()
@@ -107,6 +99,27 @@ fn kl_divergence_after_barnes_hut_is_finite_and_nonnegative() {
     assert!(kl.is_finite() && kl >= 0.0, "{kl}");
 }
 
+/// Smoke test for the parallel tree build and the force and reduction passes. N is above the
+/// parallel build threshold, so the children are genuinely built on the thread pool.
+#[test]
+fn parallel_barnes_hut_build_smoke() {
+    const N: usize = 160;
+    const DIM: usize = 4;
+    let data = lcg_samples(N, DIM, 5);
+    let samples: Vec<&[f32]> = data.chunks(DIM).collect();
+    let n_neighbors = (3.0 * PERPLEXITY) as usize;
+    let neighbors = brute_force_neighbors(&samples, n_neighbors);
+
+    let mut tsne: tSNE<f32, &[f32]> = tSNE::new(&samples);
+    tsne.perplexity(PERPLEXITY)
+        .epochs(3)
+        .barnes_hut_with_neighbors(THETA, &neighbors);
+
+    let embedding = tsne.embedding();
+    assert_eq!(embedding.len(), N * NO_DIMS as usize);
+    assert!(embedding.iter().all(|v| v.is_finite()));
+}
+
 #[test]
 fn kl_divergence_after_exact_is_finite_and_nonnegative() {
     const N: usize = 60;
@@ -114,9 +127,8 @@ fn kl_divergence_after_exact_is_finite_and_nonnegative() {
     let data = lcg_samples(N, DIM, 7);
     let samples: Vec<&[f32]> = data.chunks(DIM).collect();
 
-    let mut tsne = tSNE::new(&samples);
-    tsne.embedding_dim(NO_DIMS)
-        .perplexity(PERPLEXITY)
+    let mut tsne: tSNE<f32, &[f32]> = tSNE::new(&samples);
+    tsne.perplexity(PERPLEXITY)
         .epochs(100)
         .exact(|a, b| a.iter().zip(b.iter()).map(|(x, y)| (x - y).powi(2)).sum());
 
@@ -131,9 +143,8 @@ fn exact_tsne() {
         crate::load_csv("iris.csv", true, Some(&[4]), |float| float.parse().unwrap()).unwrap();
     let samples: Vec<&[f32]> = data.chunks(D).collect::<Vec<&[f32]>>();
 
-    let mut tsne = tSNE::new(&samples);
-    tsne.embedding_dim(NO_DIMS)
-        .perplexity(PERPLEXITY)
+    let mut tsne: tSNE<f32, &[f32]> = tSNE::new(&samples);
+    tsne.perplexity(PERPLEXITY)
         .epochs(EPOCHS)
         .exact(|sample_a, sample_b| {
             sample_a
@@ -159,9 +170,8 @@ fn barnes_hut_tsne() {
         crate::load_csv("iris.csv", true, Some(&[4]), |float| float.parse().unwrap()).unwrap();
     let samples: Vec<&[f32]> = data.chunks(D).collect::<Vec<&[f32]>>();
 
-    let mut tsne = tSNE::new(&samples);
-    tsne.embedding_dim(NO_DIMS)
-        .perplexity(PERPLEXITY)
+    let mut tsne: tSNE<f32, &[f32]> = tSNE::new(&samples);
+    tsne.perplexity(PERPLEXITY)
         .epochs(EPOCHS)
         .barnes_hut(THETA, |sample_a, sample_b| {
             sample_a
@@ -198,9 +208,8 @@ fn epoch_callback_reports_each_barnes_hut_epoch() {
     let mut last_snapshot: Vec<f32> = Vec::new();
 
     let embedding = {
-        let mut tsne = tSNE::new(&samples);
-        tsne.embedding_dim(NO_DIMS)
-            .perplexity(PERPLEXITY)
+        let mut tsne: tSNE<f32, &[f32]> = tSNE::new(&samples);
+        tsne.perplexity(PERPLEXITY)
             .epochs(RUN_EPOCHS)
             .epoch_callback(|epoch, snapshot| {
                 assert_eq!(snapshot.len(), N * NO_DIMS as usize);
@@ -240,9 +249,8 @@ fn epoch_callback_reports_each_exact_epoch() {
     let mut last_snapshot: Vec<f32> = Vec::new();
 
     let embedding = {
-        let mut tsne = tSNE::new(&samples);
-        tsne.embedding_dim(NO_DIMS)
-            .perplexity(PERPLEXITY)
+        let mut tsne: tSNE<f32, &[f32]> = tSNE::new(&samples);
+        tsne.perplexity(PERPLEXITY)
             .epochs(RUN_EPOCHS)
             .epoch_callback(|epoch, snapshot| {
                 assert_eq!(snapshot.len(), N * NO_DIMS as usize);
@@ -287,9 +295,8 @@ fn epoch_callback_accepts_non_send_closure() {
     let epochs_seen = Rc::new(RefCell::new(Vec::<usize>::new()));
     let sink = Rc::clone(&epochs_seen);
 
-    let mut tsne = tSNE::new(&samples);
-    tsne.embedding_dim(NO_DIMS)
-        .perplexity(PERPLEXITY)
+    let mut tsne: tSNE<f32, &[f32]> = tSNE::new(&samples);
+    tsne.perplexity(PERPLEXITY)
         .epochs(RUN_EPOCHS)
         .epoch_callback(move |epoch, _snapshot| {
             sink.borrow_mut().push(epoch);
@@ -321,9 +328,8 @@ fn warm_start_begins_from_initial_embedding_barnes_hut() {
 
     // A plausible layout to continue from.
     let seed = {
-        let mut tsne = tSNE::new(&samples);
-        tsne.embedding_dim(NO_DIMS)
-            .perplexity(PERPLEXITY)
+        let mut tsne: tSNE<f32, &[f32]> = tSNE::new(&samples);
+        tsne.perplexity(PERPLEXITY)
             .epochs(300)
             .barnes_hut(THETA, |sample_a, sample_b| {
                 sample_a
@@ -338,9 +344,8 @@ fn warm_start_begins_from_initial_embedding_barnes_hut() {
 
     let mut first_snapshot: Vec<f32> = Vec::new();
     {
-        let mut tsne = tSNE::new(&samples);
-        tsne.embedding_dim(NO_DIMS)
-            .perplexity(PERPLEXITY)
+        let mut tsne: tSNE<f32, &[f32]> = tSNE::new(&samples);
+        tsne.perplexity(PERPLEXITY)
             .epochs(5)
             .stop_lying_epoch(0)
             .momentum_switch_epoch(0)
@@ -390,9 +395,8 @@ fn warm_start_begins_from_initial_embedding_exact() {
 
     // A plausible layout to continue from.
     let seed = {
-        let mut tsne = tSNE::new(&samples);
-        tsne.embedding_dim(NO_DIMS)
-            .perplexity(PERPLEXITY)
+        let mut tsne: tSNE<f32, &[f32]> = tSNE::new(&samples);
+        tsne.perplexity(PERPLEXITY)
             .epochs(300)
             .exact(|sample_a, sample_b| {
                 sample_a
@@ -406,9 +410,8 @@ fn warm_start_begins_from_initial_embedding_exact() {
 
     let mut first_snapshot: Vec<f32> = Vec::new();
     {
-        let mut tsne = tSNE::new(&samples);
-        tsne.embedding_dim(NO_DIMS)
-            .perplexity(PERPLEXITY)
+        let mut tsne: tSNE<f32, &[f32]> = tSNE::new(&samples);
+        tsne.perplexity(PERPLEXITY)
             .epochs(5)
             .stop_lying_epoch(0)
             .momentum_switch_epoch(0)
@@ -446,7 +449,7 @@ fn warm_start_begins_from_initial_embedding_exact() {
 }
 
 /// The Barnes-Hut fit must reject a seed whose length does not match
-/// `n_samples * embedding_dim`.
+/// `n_samples * D`.
 #[test]
 #[should_panic(expected = "initial embedding has")]
 fn warm_start_rejects_wrong_length_barnes_hut() {
@@ -456,9 +459,8 @@ fn warm_start_rejects_wrong_length_barnes_hut() {
     let data = lcg_samples(N, DIM, 7);
     let samples: Vec<&[f32]> = data.chunks(DIM).collect();
 
-    let mut tsne = tSNE::new(&samples);
-    tsne.embedding_dim(NO_DIMS)
-        .perplexity(PERPLEXITY)
+    let mut tsne: tSNE<f32, &[f32]> = tSNE::new(&samples);
+    tsne.perplexity(PERPLEXITY)
         .epochs(1)
         .initial_embedding([0.0; 7])
         .barnes_hut(THETA, |sample_a, sample_b| {
@@ -482,9 +484,8 @@ fn warm_start_rejects_wrong_length_exact() {
     let data = lcg_samples(N, DIM, 7);
     let samples: Vec<&[f32]> = data.chunks(DIM).collect();
 
-    let mut tsne = tSNE::new(&samples);
-    tsne.embedding_dim(NO_DIMS)
-        .perplexity(PERPLEXITY)
+    let mut tsne: tSNE<f32, &[f32]> = tSNE::new(&samples);
+    tsne.perplexity(PERPLEXITY)
         .epochs(1)
         .initial_embedding([0.0; 7])
         .exact(|sample_a, sample_b| {
@@ -507,9 +508,8 @@ fn warm_start_seed_is_consumed_by_the_fit() {
     let samples: Vec<&[f32]> = data.chunks(DIM).collect();
 
     let seed = {
-        let mut tsne = tSNE::new(&samples);
-        tsne.embedding_dim(NO_DIMS)
-            .perplexity(PERPLEXITY)
+        let mut tsne: tSNE<f32, &[f32]> = tSNE::new(&samples);
+        tsne.perplexity(PERPLEXITY)
             .epochs(300)
             .barnes_hut(THETA, |sample_a, sample_b| {
                 sample_a
@@ -523,9 +523,8 @@ fn warm_start_seed_is_consumed_by_the_fit() {
     };
 
     let mut second_run_first_snapshot: Vec<f32> = Vec::new();
-    let mut tsne = tSNE::new(&samples);
-    tsne.embedding_dim(NO_DIMS)
-        .perplexity(PERPLEXITY)
+    let mut tsne: tSNE<f32, &[f32]> = tSNE::new(&samples);
+    tsne.perplexity(PERPLEXITY)
         .epochs(1)
         .initial_embedding(&seed[..]);
 
@@ -584,9 +583,8 @@ fn stop_lying_epoch_zero_skips_exaggeration_barnes_hut() {
 
     // A plausible layout to continue from.
     let seed = {
-        let mut tsne = tSNE::new(&samples);
-        tsne.embedding_dim(NO_DIMS)
-            .perplexity(PERPLEXITY)
+        let mut tsne: tSNE<f32, &[f32]> = tSNE::new(&samples);
+        tsne.perplexity(PERPLEXITY)
             .epochs(300)
             .barnes_hut(THETA, |sample_a, sample_b| {
                 sample_a
@@ -602,9 +600,8 @@ fn stop_lying_epoch_zero_skips_exaggeration_barnes_hut() {
     let first_step = |stop_lying_epoch: usize| -> f32 {
         let mut first_snapshot: Vec<f32> = Vec::new();
         {
-            let mut tsne = tSNE::new(&samples);
-            tsne.embedding_dim(NO_DIMS)
-                .perplexity(PERPLEXITY)
+            let mut tsne: tSNE<f32, &[f32]> = tSNE::new(&samples);
+            tsne.perplexity(PERPLEXITY)
                 .epochs(1)
                 .stop_lying_epoch(stop_lying_epoch)
                 .initial_embedding(&seed[..])
@@ -643,9 +640,8 @@ fn stop_lying_epoch_zero_skips_exaggeration_exact() {
 
     // A plausible layout to continue from.
     let seed = {
-        let mut tsne = tSNE::new(&samples);
-        tsne.embedding_dim(NO_DIMS)
-            .perplexity(PERPLEXITY)
+        let mut tsne: tSNE<f32, &[f32]> = tSNE::new(&samples);
+        tsne.perplexity(PERPLEXITY)
             .epochs(300)
             .exact(|sample_a, sample_b| {
                 sample_a
@@ -660,9 +656,8 @@ fn stop_lying_epoch_zero_skips_exaggeration_exact() {
     let first_step = |stop_lying_epoch: usize| -> f32 {
         let mut first_snapshot: Vec<f32> = Vec::new();
         {
-            let mut tsne = tSNE::new(&samples);
-            tsne.embedding_dim(NO_DIMS)
-                .perplexity(PERPLEXITY)
+            let mut tsne: tSNE<f32, &[f32]> = tSNE::new(&samples);
+            tsne.perplexity(PERPLEXITY)
                 .epochs(1)
                 .stop_lying_epoch(stop_lying_epoch)
                 .initial_embedding(&seed[..])
@@ -729,36 +724,28 @@ fn barnes_hut_with_neighbors_matches_vptree_path() {
     // A seed so both fits start from the very same embedding.
     let seed = lcg_samples(N, NO_DIMS as usize, 99);
 
-    // Pin to one rayon thread: the parallel reductions in the fit accumulate in a
-    // thread-count dependent order, which the chaotic gradient descent would
-    // amplify, so single threaded keeps both paths bitwise reproducible.
-    let pool = rayon::ThreadPoolBuilder::new()
-        .num_threads(1)
-        .build()
-        .unwrap();
-
-    let reference = pool.install(|| {
-        let mut tsne = tSNE::new(&samples);
-        tsne.embedding_dim(NO_DIMS)
-            .perplexity(PERPLEXITY)
+    // Both fits run on the default pool: the pipeline is deterministic at any thread count, so the
+    // tree's neighbors fed to `barnes_hut_with_neighbors` reproduce the `barnes_hut` embedding.
+    let reference = {
+        let mut tsne: tSNE<f32, &[f32]> = tSNE::new(&samples);
+        tsne.perplexity(PERPLEXITY)
             .epochs(100)
             .initial_embedding(&seed[..])
             .barnes_hut(THETA, |a, b| euclidean(a, b));
         tsne.embedding()
-    });
+    };
 
     let n_neighbors = (3.0 * PERPLEXITY) as usize;
     let neighbors = brute_force_neighbors(&samples, n_neighbors);
 
-    let candidate = pool.install(|| {
-        let mut tsne = tSNE::new(&samples);
-        tsne.embedding_dim(NO_DIMS)
-            .perplexity(PERPLEXITY)
+    let candidate = {
+        let mut tsne: tSNE<f32, &[f32]> = tSNE::new(&samples);
+        tsne.perplexity(PERPLEXITY)
             .epochs(100)
             .initial_embedding(&seed[..])
             .barnes_hut_with_neighbors(THETA, &neighbors);
         tsne.embedding()
-    });
+    };
 
     assert_eq!(candidate, reference);
 }
@@ -778,9 +765,8 @@ fn barnes_hut_with_neighbors_rejects_ragged_rows() {
     // Make one row shorter than the others.
     neighbors[0].pop();
 
-    let mut tsne = tSNE::new(&samples);
-    tsne.embedding_dim(NO_DIMS)
-        .perplexity(PERPLEXITY)
+    let mut tsne: tSNE<f32, &[f32]> = tSNE::new(&samples);
+    tsne.perplexity(PERPLEXITY)
         .epochs(1)
         .barnes_hut_with_neighbors(THETA, &neighbors);
 }
@@ -800,9 +786,8 @@ fn barnes_hut_with_neighbors_rejects_out_of_range_index() {
     // Point one neighbor at a sample that does not exist.
     neighbors[0][0].index = N;
 
-    let mut tsne = tSNE::new(&samples);
-    tsne.embedding_dim(NO_DIMS)
-        .perplexity(PERPLEXITY)
+    let mut tsne: tSNE<f32, &[f32]> = tSNE::new(&samples);
+    tsne.perplexity(PERPLEXITY)
         .epochs(1)
         .barnes_hut_with_neighbors(THETA, &neighbors);
 }
@@ -915,9 +900,8 @@ fn barnes_hut_separates_clusters_at_large_input_scale() {
     }
     let samples: Vec<&[f32]> = data.chunks(DIM).collect();
 
-    let mut tsne = tSNE::new(&samples);
-    tsne.embedding_dim(2)
-        .perplexity(30.0)
+    let mut tsne: tSNE<f32, &[f32]> = tSNE::new(&samples);
+    tsne.perplexity(30.0)
         .epochs(500)
         .barnes_hut(THETA, |sample_a, sample_b| {
             sample_a
@@ -955,5 +939,104 @@ fn barnes_hut_separates_clusters_at_large_input_scale() {
     assert!(
         same_cluster as f64 / n as f64 > 0.95,
         "clusters not separated: only {same_cluster}/{n} points have a same-cluster nearest neighbour"
+    );
+}
+
+/// With neighbours supplied (so the vantage point tree's randomness is out of the picture), the
+/// Barnes-Hut loop is reproducible bit for bit across runs on the default multi-threaded pool. N is
+/// above the parallel build threshold, so the tree is built in parallel.
+#[test]
+fn barnes_hut_is_reproducible_run_to_run() {
+    const N: usize = 600;
+    const DIM: usize = 4;
+    let data = lcg_samples(N, DIM, 11);
+    let samples: Vec<&[f32]> = data.chunks(DIM).collect();
+    let n_neighbors = (3.0 * PERPLEXITY) as usize;
+    let neighbors = brute_force_neighbors(&samples, n_neighbors);
+    let seed = lcg_samples(N, NO_DIMS as usize, 99);
+
+    let run = || {
+        let mut tsne: tSNE<f32, &[f32]> = tSNE::new(&samples);
+        tsne.perplexity(PERPLEXITY)
+            .epochs(150)
+            .initial_embedding(&seed[..])
+            .barnes_hut_with_neighbors(THETA, &neighbors);
+        tsne.embedding().to_vec()
+    };
+
+    let first = run();
+    let second = run();
+    assert_eq!(
+        first, second,
+        "Barnes-Hut embedding is not reproducible run to run"
+    );
+}
+
+/// Regression test for the parallel build, white box. The counting and scatter passes reuse each
+/// child's `cumulative_size` as a prefix cursor, so an empty child can be left holding a stale
+/// nonzero value. If the aggregation then treats it as real mass at the origin, the cell centres of
+/// mass are pulled off, corrupting the Barnes-Hut forces. This checks the structural invariants a
+/// correct build maintains: stored points stay inside their cells and each cell's centre of mass
+/// lies within the cell. `SPTree::new` additionally debug-asserts point conservation (leaf mass
+/// plus boundary-crack drops equals the input count). The tree is built over a 2D point cloud (the
+/// embedding space the real tree partitions), offset far from the origin so any centre of mass
+/// dragged toward it lands outside its cell. N is above the parallel build threshold.
+#[test]
+fn sptree_build_maintains_invariants() {
+    const N: usize = 2_000;
+    let mut data = lcg_samples(N, 2, 17);
+    for value in data.iter_mut() {
+        *value += 100.0;
+    }
+
+    let tree = tsne::sptree::SPTree::<f32, 2>::new(&data, N);
+
+    assert!(tree.is_correct(), "stored points escaped their cells");
+    assert!(
+        tree.centers_of_mass_within_cells(),
+        "a cell centre of mass escaped its cell, the build aggregated phantom mass"
+    );
+}
+
+/// End-to-end regression test for the same bug, reproducing the symptom directly: corrupted
+/// repulsive forces let attraction collapse the whole embedding onto a handful of coordinates. A
+/// healthy run spreads the points out, so most embedded positions are distinct. N is above the
+/// parallel build threshold.
+#[test]
+fn barnes_hut_does_not_collapse_embedding() {
+    use std::collections::HashSet;
+
+    const N: usize = 500;
+    const DIM: usize = 8;
+    let data = lcg_samples(N, DIM, 23);
+    let samples: Vec<&[f32]> = data.chunks(DIM).collect();
+
+    let mut tsne: tSNE<f32, &[f32]> = tSNE::new(&samples);
+    tsne.perplexity(30.0)
+        .epochs(1000)
+        .barnes_hut(THETA, |a, b| {
+            a.iter()
+                .zip(b.iter())
+                .map(|(x, y)| (x - y).powi(2))
+                .sum::<f32>()
+                .sqrt()
+        });
+    let embedding = tsne.embedding();
+
+    // Count distinct positions, rounded to a hundredth. The collapse piled every point onto three
+    // coordinates, a healthy embedding keeps them apart.
+    let distinct: HashSet<(i64, i64)> = embedding
+        .chunks_exact(2)
+        .map(|point| {
+            (
+                (point[0] * 100.0).round() as i64,
+                (point[1] * 100.0).round() as i64,
+            )
+        })
+        .collect();
+    assert!(
+        distinct.len() > N / 2,
+        "embedding collapsed: only {} distinct positions for {N} points",
+        distinct.len()
     );
 }

--- a/src/tsne/mod.rs
+++ b/src/tsne/mod.rs
@@ -11,12 +11,16 @@ use rayon::{
         IndexedParallelIterator, IntoParallelRefIterator, IntoParallelRefMutIterator,
         ParallelIterator,
     },
-    slice::ParallelSliceMut,
+    slice::{ParallelSlice, ParallelSliceMut},
 };
 
 use rand_distr::{Distribution, Normal};
 
 use num_traits::{AsPrimitive, Float};
+
+/// Samples per block for the deterministic parallel reductions: blocks are summed sequentially in
+/// parallel and combined in index order, so the result is independent of the work-stealing schedule.
+const REDUCTION_BLOCK: usize = 1024;
 
 /// Checks whether the perplexity is too large for the number of samples.
 ///
@@ -255,6 +259,18 @@ where
         .for_each(|p| *p /= p_values_row_sum + T::epsilon());
 }
 
+/// Deterministic parallel sum of `values`: fixed-size blocks are summed sequentially in parallel,
+/// then combined in index order, so the result does not depend on the work-stealing schedule.
+pub(super) fn deterministic_sum<T: Float + Send + Sync + Sum>(values: &[T]) -> T {
+    const BLOCK: usize = 4096;
+    values
+        .par_chunks(BLOCK)
+        .map(|block| block.iter().copied().sum::<T>())
+        .collect::<Vec<T>>()
+        .into_iter()
+        .fold(T::zero(), |total, partial| total + partial)
+}
+
 /// Normalizes the P values.
 ///
 /// # Arguments
@@ -263,7 +279,7 @@ where
 pub(super) fn normalize_p_values<T: Float + Send + Sync + MulAssign + DivAssign + Sum>(
     p_values: &mut [T],
 ) {
-    let p_values_sum: T = p_values.par_iter().map(|p| *p).sum();
+    let p_values_sum: T = deterministic_sum(p_values);
     let twelve = T::from(12.0).unwrap();
     p_values.par_iter_mut().for_each(|p| {
         *p /= p_values_sum + T::epsilon();
@@ -424,45 +440,43 @@ pub(super) fn stop_lying<T: Float + Send + Sync + DivAssign>(p_values: &mut [T])
     p_values.par_iter_mut().for_each(|p| *p /= twelve);
 }
 
-/// Makes the solution zero mean. The embedded samples are taken in chunks of size
-/// corresponding to the embedding space dimensionality, so that each chunks
-/// corresponds to a sample. Each of the so obtained samples is summed element wise
-/// to the means buffer. At last, each mean of the means buffer is divided by the number
-/// of samples.
-///
-/// # Arguments
-///
-/// * ` means` - where the means of each component of the embedding are stored.
-///
-/// * `y` - embedding.
-///
-/// * `n_samples` -  number of samples in the embedding.
-///
-/// * `embedding_dim`- dimensionality of the embedding space.
-pub(super) fn zero_mean<T>(means: &mut [T], y: &mut [T], n_samples: usize, embedding_dim: usize)
+/// Recenters `y` to zero mean. The per-dimension sums are reduced deterministically (fixed-size
+/// blocks summed in parallel, then combined in index order) and subtracted in parallel.
+pub(super) fn zero_mean<T, const D: usize>(y: &mut [T], n_samples: usize)
 where
     T: Float + Send + Sync + Copy + AddAssign + DivAssign + SubAssign,
 {
-    // Not parallel as it accumulates into means.
-    y.chunks(embedding_dim).for_each(|embedded_sample| {
+    let block_len = REDUCTION_BLOCK * D;
+    let partials: Vec<[T; D]> = y
+        .par_chunks(block_len)
+        .map(|block| {
+            let mut totals = [T::zero(); D];
+            block.chunks(D).for_each(|sample| {
+                totals
+                    .iter_mut()
+                    .zip(sample.iter())
+                    .for_each(|(total, el)| *total += *el);
+            });
+            totals
+        })
+        .collect();
+
+    let mut means = [T::zero(); D];
+    for partial in &partials {
         means
             .iter_mut()
-            .zip(embedded_sample.iter())
-            .for_each(|(mean, el)| *mean += *el);
-    });
-
+            .zip(partial.iter())
+            .for_each(|(mean, total)| *mean += *total);
+    }
     let n_samples = T::from(n_samples).unwrap();
-    means.iter_mut().for_each(|el| *el /= n_samples);
+    means.iter_mut().for_each(|mean| *mean /= n_samples);
 
-    y.par_chunks_mut(embedding_dim).for_each(|embedded_sample| {
-        embedded_sample
+    y.par_chunks_mut(D).for_each(|sample| {
+        sample
             .iter_mut()
             .zip(means.iter())
             .for_each(|(el, mean)| *el -= *mean);
     });
-
-    // Zeroes the mean buffer.
-    means.iter_mut().for_each(|el| *el = T::zero());
 }
 
 /// Evaluate t-SNE cost function exactly.
@@ -474,27 +488,20 @@ where
 /// * `y` - current embedding.
 ///
 /// * `n_samples` - number of samples in the embedding;
-///
-/// * `embedding_dim` - dimensionality of the embedding space.
-pub(crate) fn evaluate_error<T>(
-    p_values: &[T],
-    y: &[T],
-    n_samples: usize,
-    embedding_dim: usize,
-) -> T
+pub(crate) fn evaluate_error<T, const D: usize>(p_values: &[T], y: &[T], n_samples: usize) -> T
 where
     T: Float + Send + Sync + AddAssign + Add + DivAssign + Sum,
 {
     let mut distances: Vec<T> = vec![T::zero(); n_samples * n_samples];
     compute_pairwise_distance_matrix(
         &mut distances,
-        |a: &[T], b: &[T]| {
+        |a: &[T; D], b: &[T; D]| {
             a.iter()
                 .zip(b.iter())
                 .map(|(aa, bb)| (*aa - *bb).powi(2))
                 .sum::<T>()
         },
-        |i| &y[i * embedding_dim..(i + 1) * embedding_dim],
+        |i| (&y[i * D..(i + 1) * D]).try_into().unwrap(),
         n_samples,
     );
 
@@ -534,16 +541,13 @@ where
 ///
 /// * `n_samples` - number of samples.
 ///
-/// * `embedding_dim` - dimensionality of the embedding space.
-///
 /// * `theta` - threshold for the Barnes-Hut algorithm.
-pub(crate) fn evaluate_error_approximately<T>(
+pub(crate) fn evaluate_error_approximately<T, const D: usize>(
     p_rows: &[usize],
     p_columns: &[usize],
     p_values: &[T],
     y: &[T],
     n_samples: usize,
-    embedding_dim: usize,
     theta: T,
 ) -> T
 where
@@ -551,20 +555,15 @@ where
 {
     // Get estimate of normalization term.
     let q_sum = {
-        let tree = sptree::SPTree::new(embedding_dim, y, n_samples);
+        let tree = sptree::SPTree::<T, D>::new(y, n_samples);
         let mut q_sums: Vec<T> = vec![T::zero(); n_samples];
 
-        let mut buffer: Vec<T> = vec![T::zero(); n_samples * embedding_dim];
-        let mut negative_forces: Vec<T> = vec![T::zero(); n_samples * embedding_dim];
-
-        q_sums
-            .par_iter_mut()
-            .zip(negative_forces.par_chunks_mut(embedding_dim))
-            .zip(buffer.par_chunks_mut(embedding_dim))
-            .enumerate()
-            .for_each(|(index, ((sum, negative_forces_row), buffer_row))| {
-                tree.compute_non_edge_forces(index, theta, negative_forces_row, buffer_row, sum);
-            });
+        q_sums.par_iter_mut().enumerate().for_each(|(index, sum)| {
+            // Local scratch: the repulsive forces are not needed here, only their q_sum.
+            let mut buffer = [T::zero(); D];
+            let mut negative_forces = [T::zero(); D];
+            tree.compute_non_edge_forces(index, theta, &mut negative_forces, &mut buffer, sum);
+        });
 
         q_sums.par_iter().map(|sum| *sum).sum::<T>()
     };
@@ -575,9 +574,9 @@ where
         .par_iter_mut()
         .enumerate()
         .for_each(|(index, cost)| {
-            let sample_a = &y[index * embedding_dim..(index + 1) * embedding_dim];
+            let sample_a = &y[index * D..(index + 1) * D];
             for n in p_rows[index]..p_rows[index + 1] {
-                let sample_b = &y[p_columns[n] * embedding_dim..(p_columns[n] + 1) * embedding_dim];
+                let sample_b = &y[p_columns[n] * D..(p_columns[n] + 1) * D];
 
                 let mut q = sample_a
                     .iter()

--- a/src/tsne/mod.rs
+++ b/src/tsne/mod.rs
@@ -18,10 +18,6 @@ use rand_distr::{Distribution, Normal};
 
 use num_traits::{AsPrimitive, Float};
 
-/// Samples per block for the deterministic parallel reductions: blocks are summed sequentially in
-/// parallel and combined in index order, so the result is independent of the work-stealing schedule.
-const REDUCTION_BLOCK: usize = 1024;
-
 /// Checks whether the perplexity is too large for the number of samples.
 ///
 /// # Arguments
@@ -259,25 +255,13 @@ where
         .for_each(|p| *p /= p_values_row_sum + T::epsilon());
 }
 
-/// Deterministic parallel sum of `values`: fixed-size blocks are summed sequentially in parallel,
-/// then combined in index order, so the result does not depend on the work-stealing schedule.
-pub(super) fn deterministic_sum<T: Float + Send + Sync + Sum>(values: &[T]) -> T {
-    const BLOCK: usize = 4096;
-    values
-        .par_chunks(BLOCK)
-        .map(|block| block.iter().copied().sum::<T>())
-        .collect::<Vec<T>>()
-        .into_iter()
-        .fold(T::zero(), |total, partial| total + partial)
-}
-
 /// Normalizes the P values.
 ///
 /// # Arguments
 ///
 /// `p_values` - values of the P distribution.
 pub(super) fn normalize_p_values<T: Float + Send + Sync + MulAssign + Sum>(p_values: &mut [T]) {
-    let p_values_sum: T = deterministic_sum(p_values);
+    let p_values_sum: T = p_values.par_iter().copied().sum::<T>();
     // Fold the normalization and the early-exaggeration factor into one reciprocal, so the hot pass
     // is a single multiply per value rather than a divide and a multiply.
     let scale = T::from(12.0).unwrap() / (p_values_sum + T::epsilon());
@@ -432,39 +416,37 @@ pub(super) fn update_solution<T>(
 /// # Arguments
 ///
 /// `p_values` - P distribution.
-pub(super) fn stop_lying<T: Float + Send + Sync + DivAssign>(p_values: &mut [T]) {
-    let twelve = T::from(12.0).unwrap();
-    p_values.par_iter_mut().for_each(|p| *p /= twelve);
+pub(super) fn stop_lying<T: Float + Send + Sync + MulAssign>(p_values: &mut [T]) {
+    let scale = T::one() / T::from(12.0).unwrap();
+    p_values.par_iter_mut().for_each(|p| *p *= scale);
 }
 
-/// Recenters `y` to zero mean. The per-dimension sums are reduced deterministically (fixed-size
-/// blocks summed in parallel, then combined in index order) and subtracted in parallel.
+/// Recenters `y` to zero mean. The per-dimension sums and the subtraction are both parallel passes.
 pub(super) fn zero_mean<T, const D: usize>(y: &mut [T], n_samples: usize)
 where
     T: Float + Send + Sync + Copy + AddAssign + DivAssign + SubAssign,
 {
-    let block_len = REDUCTION_BLOCK * D;
-    let partials: Vec<[T; D]> = y
-        .par_chunks(block_len)
-        .map(|block| {
-            let mut totals = [T::zero(); D];
-            block.chunks(D).for_each(|sample| {
+    let mut means = y
+        .par_chunks_exact(D)
+        .fold(
+            || [T::zero(); D],
+            |mut totals, sample| {
                 totals
                     .iter_mut()
                     .zip(sample.iter())
                     .for_each(|(total, el)| *total += *el);
-            });
-            totals
-        })
-        .collect();
-
-    let mut means = [T::zero(); D];
-    for partial in &partials {
-        means
-            .iter_mut()
-            .zip(partial.iter())
-            .for_each(|(mean, total)| *mean += *total);
-    }
+                totals
+            },
+        )
+        .reduce(
+            || [T::zero(); D],
+            |mut left, right| {
+                left.iter_mut()
+                    .zip(right.iter())
+                    .for_each(|(total, partial)| *total += *partial);
+                left
+            },
+        );
     let n_samples = T::from(n_samples).unwrap();
     means.iter_mut().for_each(|mean| *mean /= n_samples);
 

--- a/src/tsne/mod.rs
+++ b/src/tsne/mod.rs
@@ -276,15 +276,12 @@ pub(super) fn deterministic_sum<T: Float + Send + Sync + Sum>(values: &[T]) -> T
 /// # Arguments
 ///
 /// `p_values` - values of the P distribution.
-pub(super) fn normalize_p_values<T: Float + Send + Sync + MulAssign + DivAssign + Sum>(
-    p_values: &mut [T],
-) {
+pub(super) fn normalize_p_values<T: Float + Send + Sync + MulAssign + Sum>(p_values: &mut [T]) {
     let p_values_sum: T = deterministic_sum(p_values);
-    let twelve = T::from(12.0).unwrap();
-    p_values.par_iter_mut().for_each(|p| {
-        *p /= p_values_sum + T::epsilon();
-        *p *= twelve;
-    });
+    // Fold the normalization and the early-exaggeration factor into one reciprocal, so the hot pass
+    // is a single multiply per value rather than a divide and a multiply.
+    let scale = T::from(12.0).unwrap() / (p_values_sum + T::epsilon());
+    p_values.par_iter_mut().for_each(|p| *p *= scale);
 }
 
 /// Symmetrizes a sparse P matrix.
@@ -493,6 +490,7 @@ where
     T: Float + Send + Sync + AddAssign + Add + DivAssign + Sum,
 {
     let mut distances: Vec<T> = vec![T::zero(); n_samples * n_samples];
+    let (points, _) = y.as_chunks::<D>();
     compute_pairwise_distance_matrix(
         &mut distances,
         |a: &[T; D], b: &[T; D]| {
@@ -501,7 +499,7 @@ where
                 .map(|(aa, bb)| (*aa - *bb).powi(2))
                 .sum::<T>()
         },
-        |i| (&y[i * D..(i + 1) * D]).try_into().unwrap(),
+        |i| &points[*i],
         n_samples,
     );
 
@@ -512,7 +510,10 @@ where
         .for_each(|(q, d)| *q = T::one() / (T::one() + *d));
 
     let q_sum = q_values.par_iter().map(|q| *q).sum::<T>();
-    q_values.par_iter_mut().for_each(|q| *q /= q_sum);
+    let inverse_q_sum = T::one() / q_sum;
+    q_values
+        .par_iter_mut()
+        .for_each(|q| *q = *q * inverse_q_sum);
 
     // Kullback-Leibler divergence.
     p_values
@@ -567,6 +568,7 @@ where
 
         q_sums.par_iter().map(|sum| *sum).sum::<T>()
     };
+    let inverse_q_sum = T::one() / q_sum;
 
     let mut partials: Vec<T> = vec![T::zero(); n_samples];
 
@@ -583,7 +585,7 @@ where
                     .zip(sample_b.iter())
                     .map(|(a, b)| (*a - *b).powi(2))
                     .sum::<T>();
-                q = (T::one() / (T::one() + q)) / q_sum;
+                q = (T::one() / (T::one() + q)) * inverse_q_sum;
 
                 // Kullback-Leibler divergence.
                 *cost += p_values[index]

--- a/src/tsne/sptree.rs
+++ b/src/tsne/sptree.rs
@@ -5,34 +5,25 @@ use std::{
 
 use num_traits::{Float, NumCast};
 
-/// A cell for the SPTree.
-struct SPTreeCell<T: Float + Send + Sync> {
-    corner: Vec<T>,
-    width: Vec<T>,
+use rayon::prelude::*;
+
+/// Subtrees of at least this many points build their children in parallel. Smaller ones stay
+/// sequential, where the work-stealing overhead would dominate.
+const PARALLEL_BUILD_THRESHOLD: usize = 128;
+
+/// A cell of an [`SPTree`]: `corner` is its centre, `width` its half extent along each dimension.
+struct SPTreeCell<T: Float + Send + Sync, const D: usize> {
+    corner: [T; D],
+    width: [T; D],
 }
 
-impl<T: Float + Send + Sync> SPTreeCell<T> {
-    /// Constructs a cell.
-    ///
-    /// # Arguments
-    ///
-    /// * `corner` - corner of the cell.
-    ///
-    /// * `width` - width of the cell.
-    fn new(corner: Vec<T>, width: Vec<T>) -> Self {
+impl<T: Float + Send + Sync, const D: usize> SPTreeCell<T, D> {
+    fn new(corner: [T; D], width: [T; D]) -> Self {
         Self { corner, width }
     }
 
-    /// Checks whether a point lies in a cell.
-    ///
-    /// # Arguments
-    ///
-    /// `point` - a point.
-    fn contains_point(&self, point: &[T]) -> bool {
-        debug_assert_eq!(point.len(), self.corner.len());
-        debug_assert_eq!(point.len(), self.width.len());
-
-        // All the point components lie inside the cell.
+    /// Whether `point` lies in the cell.
+    fn contains_point(&self, point: &[T; D]) -> bool {
         !point
             .iter()
             .zip(self.corner.iter())
@@ -41,44 +32,33 @@ impl<T: Float + Send + Sync> SPTreeCell<T> {
     }
 }
 
-/// An SPTree.
-pub struct SPTree<'a, T>
+/// A space partitioning tree over the `D` dimensional embedding (a quadtree for `D == 2`, an
+/// octree for `D == 3`). Each cell holds the centre of mass and point count of its subtree, which
+/// is what the Barnes-Hut approximation summarizes.
+pub struct SPTree<'a, T, const D: usize>
 where
     T: Float + NumCast + AddAssign + MulAssign + DivAssign + Add + Mul + Div + Send + Sync + Sum,
 {
-    dimension: usize,
     is_leaf: bool,
     cumulative_size: i64,
-    boundary: SPTreeCell<T>,
+    boundary: SPTreeCell<T, D>,
     data: &'a [T],
-    center_of_mass: Vec<T>,
+    center_of_mass: [T; D],
     index: Option<usize>,
-    children: Vec<SPTree<'a, T>>,
-    n_children: usize,
+    children: Vec<SPTree<'a, T, D>>,
 }
 
-impl<'a, T> SPTree<'a, T>
+impl<'a, T, const D: usize> SPTree<'a, T, D>
 where
     T: Float + NumCast + AddAssign + MulAssign + DivAssign + Add + Mul + Div + Send + Sync + Sum,
 {
-    /// The constructor for SPTree, builds the tree too.
-    ///
-    /// # Arguments
-    ///
-    /// * `dimension` - dimensions of a point.
-    ///
-    /// * `data` - data to build the tree from.
-    ///
-    /// * `n_samples` - number of points in `inp_data`.
-    pub(crate) fn new(dimension: usize, data: &'a [T], n_samples: usize) -> Self {
-        // Mean for each dimension.
-        let mut mean: Vec<T> = vec![T::zero(); dimension];
-        // Min for each dimension.
-        let mut min: Vec<T> = vec![T::max_value(); dimension];
-        // Max for each dimension.
-        let mut max: Vec<T> = vec![-T::max_value(); dimension];
-        // Compute the boundaries of SPTree.
-        data.chunks(dimension).for_each(|sample| {
+    /// Builds the tree over `data`, a flat buffer of `n_samples` points of `D` components each.
+    pub(crate) fn new(data: &'a [T], n_samples: usize) -> Self {
+        // Mean, min and max of each dimension size the root cell.
+        let mut mean = [T::zero(); D];
+        let mut min = [T::max_value(); D];
+        let mut max = [-T::max_value(); D];
+        data.chunks_exact(D).for_each(|sample| {
             sample
                 .iter()
                 .zip(mean.iter_mut())
@@ -94,8 +74,7 @@ where
         let denominator = T::from(n_samples).unwrap();
         mean.iter_mut().for_each(|el| *el /= denominator);
 
-        // Build SPTree.
-        let mut width: Vec<T> = vec![T::zero(); dimension];
+        let mut width = [T::zero(); D];
         width
             .iter_mut()
             .zip(mean.iter())
@@ -105,219 +84,320 @@ where
                 *w = (*max_d - *mean_d).max(*mean_d - *min_d) + T::min_positive_value();
             });
 
-        let mut tree = SPTree::new_empty(dimension, data, mean, width);
-        tree.fill(n_samples);
-
+        let mut tree = SPTree::new_empty(data, mean, width);
+        if n_samples > 0 {
+            let mut indices: Vec<usize> = (0..n_samples).collect();
+            let mut scratch: Vec<usize> = vec![0usize; n_samples];
+            let dropped = tree.build(&mut indices, &mut scratch);
+            // Every input point ends up in exactly one leaf or in a boundary-crack drop. The leaf
+            // mass (`cumulative_size`, summed up the tree) plus the drops must therefore equal the
+            // input count. This is independent of how the mass is aggregated, so it catches a
+            // miscount such as the empty-child phantom-mass regression.
+            debug_assert_eq!(
+                tree.cumulative_size as usize + dropped,
+                n_samples,
+                "SPTree lost or invented points: {} in leaves + {dropped} dropped != {n_samples}",
+                tree.cumulative_size
+            );
+        }
         tree
     }
 
-    /// Constructs an empty tree.
-    ///
-    /// # Arguments
-    ///
-    /// * `dimension` - dimensions of a point.
-    ///
-    /// * `data` - data to build the tree from.
-    ///
-    /// * `corner` - a corner for a cell.
-    ///
-    /// * `width` - cell's width.
-    fn new_empty(dimension: usize, data: &'a [T], corner: Vec<T>, width: Vec<T>) -> Self {
-        let n_children = 2usize.pow(dimension as u32);
-        let boundary = SPTreeCell::new(corner, width);
-        let children = Vec::new();
-        let center_of_mass = vec![T::zero(); dimension];
-
+    /// An empty cell with the given boundary.
+    fn new_empty(data: &'a [T], corner: [T; D], width: [T; D]) -> Self {
         SPTree {
-            children,
-            center_of_mass,
-            boundary,
+            children: Vec::new(),
+            center_of_mass: [T::zero(); D],
+            boundary: SPTreeCell::new(corner, width),
             cumulative_size: 0,
             is_leaf: true,
-            dimension,
-            n_children,
             index: None,
             data,
         }
     }
 
-    /// Inserts a point into the SPTree.
-    ///
-    /// # Arguments
-    ///
-    /// `index` - index of the point inside `data`.
-    fn insert(&mut self, index: usize) -> bool {
-        // Point to insert as a slice of data.
-        let point = &self.data[index * self.dimension..(index + 1) * self.dimension];
+    /// Point `index` as a fixed size array reference.
+    fn point(&self, index: usize) -> &[T; D] {
+        (&self.data[index * D..index * D + D])
+            .try_into()
+            .expect("a point spans exactly D components")
+    }
 
-        // Ignore objects which do not belong in this quad tree.
-        if !self.boundary.contains_point(point) {
-            false
-        } else {
-            // Online update of cumulative size and center-of-mass.
-            self.cumulative_size += 1;
-            // Update center of mass.
-            let m1: T =
-                T::from(self.cumulative_size - 1).unwrap() / T::from(self.cumulative_size).unwrap();
-            let m2: T = T::one() / T::from(self.cumulative_size).unwrap();
+    /// Children of a subdivided cell, one per orthant.
+    const fn n_children() -> usize {
+        1 << D
+    }
 
-            debug_assert_eq!(self.center_of_mass.len(), point.len(),);
+    /// Recursively builds the subtree from the point `indices`, using `scratch` (same length) to
+    /// group them by child cell. The two buffers swap roles each level so the index storage is
+    /// never reallocated. Large subtrees build their children in parallel. The structure does not
+    /// depend on insertion order.
+    fn build(&mut self, indices: &mut [usize], scratch: &mut [usize]) -> usize {
+        let len = indices.len();
+        self.cumulative_size = len as i64;
 
-            self.center_of_mass
-                .iter_mut()
-                .zip(point.iter())
-                .for_each(|(cm, &p)| {
-                    *cm *= m1;
-                    *cm += m2 * p;
-                });
+        if len == 0 {
+            return 0;
+        }
+        if len == 1 {
+            self.make_leaf(indices[0]);
+            return 0;
+        }
 
-            // If there is space in this quad tree and it is a leaf, add the object here.
-            if self.is_leaf && self.index.is_none() {
-                self.index = Some(index);
-                true
-            } else {
-                // If there's another point checks that the two points are different. Don't add
-                // duplicates for now.
-                let is_duplicate: bool = if let Some(present) = self.index {
-                    !point
-                        .iter()
-                        .zip(
-                            self.data[present * self.dimension..(present + 1) * self.dimension]
-                                .iter(),
-                        )
-                        .any(|(&pa, &pb)| (pa - pb).abs() >= T::min_positive_value())
-                } else {
-                    false
-                };
-                // The point is already in the tree.
-                if is_duplicate {
-                    true
-                } else {
-                    // Otherwise, we need to subdivide the current cell.
-                    if self.is_leaf {
-                        self.subdivide();
-                    }
-                    // Insert point in some children.
-                    self.children.iter_mut().any(|child| child.insert(index))
-                }
+        // Count points per child into the children's own `cumulative_size` (scratch the recursion
+        // overwrites), so no `2^D` bucket array is needed. Points in a boundary crack are dropped,
+        // as a sequential insertion would drop them.
+        self.create_children();
+        for &index in indices.iter() {
+            if let Some(child) = self.child_containing(index) {
+                self.children[child].cumulative_size += 1;
             }
         }
-    }
+        let occupied = self
+            .children
+            .iter()
+            .filter(|child| child.cumulative_size > 0)
+            .count();
+        let placed = self
+            .children
+            .iter()
+            .map(|child| child.cumulative_size as usize)
+            .sum::<usize>();
 
-    /// Create four children which fully divide this cell into four quads of equal area.
-    fn subdivide(&mut self) {
-        // Creates new children.
-        for i in 0..self.n_children {
-            let mut den: usize = 1;
-            let mut new_corner: Vec<T> = vec![T::zero(); self.dimension];
-            let mut new_width: Vec<T> = vec![T::zero(); self.dimension];
-
-            // Computes new corner and new width.
-            let zero_point_five = T::from(0.5).unwrap();
-            new_width
-                .iter_mut()
-                .zip(new_corner.iter_mut())
-                .zip(self.boundary.width.iter())
-                .zip(self.boundary.corner.iter())
-                .for_each(|(((nw, nc), bw), bc)| {
-                    *nw = zero_point_five * *bw;
-                    if (i / den) % 2 == 1 {
-                        *nc = *bc - zero_point_five * *bw;
-                    } else {
-                        *nc = *bc + zero_point_five * *bw;
-                    }
-                    den *= 2;
-                });
-            // Creates a new child.
-            self.children.push(SPTree::new_empty(
-                self.dimension,
-                self.data,
-                new_corner,
-                new_width,
-            ));
-        }
-
-        // Move existing points, if any, to correct children.
-        if let Some(index) = self.index {
-            self.children.iter_mut().any(|child| child.insert(index));
-            // Empty parent node.
-            self.index = None;
+        // Points that do not separate (duplicates, or all dropped) become one leaf, which also
+        // terminates the recursion. The leaf stands in for all `len` points, so none are dropped.
+        if occupied <= 1 && (placed == 0 || self.all_duplicates(indices)) {
+            self.children.clear();
+            self.make_leaf(indices[0]);
+            return 0;
         }
         self.is_leaf = false;
+        // Points that fail `child_containing` sit in a floating point boundary crack and are
+        // dropped at this level. Deeper drops are summed from the children below.
+        let dropped_here = len - placed;
+
+        // Counts become exclusive-prefix offsets, then the scatter groups indices into `scratch`,
+        // advancing each child's cursor to its window end.
+        let mut running = 0i64;
+        for child in self.children.iter_mut() {
+            let count = child.cumulative_size;
+            child.cumulative_size = running;
+            running += count;
+        }
+        for &index in indices.iter() {
+            if let Some(child) = self.child_containing(index) {
+                let position = self.children[child].cumulative_size as usize;
+                scratch[position] = index;
+                self.children[child].cumulative_size += 1;
+            }
+        }
+
+        // Give each non-empty child its window `[previous end, cumulative_size)`: grouped indices
+        // in `scratch`, fresh scratch in `indices` (the two swap roles one level down).
+        let dropped_below: usize = if placed >= PARALLEL_BUILD_THRESHOLD {
+            let mut child_indices: &mut [usize] = &mut scratch[..placed];
+            let mut child_scratch: &mut [usize] = &mut indices[..placed];
+            let mut previous_end = 0usize;
+            let mut work: Vec<(&mut SPTree<'a, T, D>, &mut [usize], &mut [usize])> =
+                Vec::with_capacity(self.children.len());
+            for child in self.children.iter_mut() {
+                let count = child.cumulative_size as usize - previous_end;
+                previous_end += count;
+                let (mine, rest_indices) = child_indices.split_at_mut(count);
+                let (my_scratch, rest_scratch) = child_scratch.split_at_mut(count);
+                child_indices = rest_indices;
+                child_scratch = rest_scratch;
+                if count != 0 {
+                    work.push((child, mine, my_scratch));
+                } else {
+                    // Empty child: clear the prefix-sum cursor left in `cumulative_size`,
+                    // otherwise it registers as phantom mass in `combine_center_of_mass`.
+                    child.cumulative_size = 0;
+                }
+            }
+            work.into_par_iter()
+                .map(|(child, mine, my_scratch)| child.build(mine, my_scratch))
+                .sum()
+        } else {
+            // Sequential build, avoiding the work list allocation.
+            let mut child_indices: &mut [usize] = &mut scratch[..placed];
+            let mut child_scratch: &mut [usize] = &mut indices[..placed];
+            let mut previous_end = 0usize;
+            let mut dropped_below = 0usize;
+            for child in self.children.iter_mut() {
+                let count = child.cumulative_size as usize - previous_end;
+                previous_end += count;
+                let (mine, rest_indices) = child_indices.split_at_mut(count);
+                let (my_scratch, rest_scratch) = child_scratch.split_at_mut(count);
+                child_indices = rest_indices;
+                child_scratch = rest_scratch;
+                if count != 0 {
+                    dropped_below += child.build(mine, my_scratch);
+                } else {
+                    child.cumulative_size = 0;
+                }
+            }
+            dropped_below
+        };
+
+        // The node's mass is the points actually in the leaves below it: the sum of its children's
+        // final `cumulative_size`. This matches the centre of mass `combine_center_of_mass` averages
+        // over the same children, and stays correct when a deeper crack drops a point.
+        self.cumulative_size = self
+            .children
+            .iter()
+            .map(|child| child.cumulative_size)
+            .sum();
+        self.combine_center_of_mass();
+
+        dropped_here + dropped_below
     }
 
-    /// Build SPTree on dataset.
-    ///
-    /// # Arguments
-    ///
-    /// `n_samples` - number of points.
-    fn fill(&mut self, n_samples: usize) {
-        (0..n_samples).for_each(|index| {
-            self.insert(index);
+    /// The child cell containing point `index`, or `None` if a floating point crack leaves it
+    /// outside every child. Same order and predicate as a sequential insertion, so it drops the
+    /// same points.
+    fn child_containing(&self, index: usize) -> Option<usize> {
+        let point = self.point(index);
+        let half = T::from(0.5).unwrap();
+        (0..Self::n_children()).find(|&child| {
+            (0..D).all(|d| {
+                let half_width = half * self.boundary.width[d];
+                let center = if (child >> d) & 1 == 1 {
+                    self.boundary.corner[d] - half_width
+                } else {
+                    self.boundary.corner[d] + half_width
+                };
+                center - half_width <= point[d] && point[d] <= center + half_width
+            })
         })
     }
 
-    /// Checks whether the tree is correct
-    pub(crate) fn is_correct(&self) -> bool {
-        // Empty nodes are correct.
-        let is_correct = if let Some(index) = self.index {
-            self.boundary
-                .contains_point(&self.data[index * self.dimension..(index + 1) * self.dimension])
-        } else {
-            true
-        };
+    /// Whether every point in `indices` equals the first, within the duplicate tolerance.
+    fn all_duplicates(&self, indices: &[usize]) -> bool {
+        let first = self.point(indices[0]);
+        indices[1..].iter().all(|&index| {
+            let point = self.point(index);
+            !first
+                .iter()
+                .zip(point.iter())
+                .any(|(&a, &b)| (a - b).abs() >= T::min_positive_value())
+        })
+    }
 
+    /// Makes this node a leaf for `index`, its centre of mass that point. `cumulative_size` is left
+    /// as set, so a leaf standing in for duplicates keeps their count.
+    fn make_leaf(&mut self, index: usize) {
+        self.index = Some(index);
+        self.is_leaf = true;
+        self.center_of_mass = *self.point(index);
+    }
+
+    /// Creates the `2^D` empty children that tile this cell.
+    fn create_children(&mut self) {
+        let half = T::from(0.5).unwrap();
+        let n_children = Self::n_children();
+        self.children.reserve_exact(n_children);
+        for i in 0..n_children {
+            let mut corner = [T::zero(); D];
+            let mut width = [T::zero(); D];
+            for d in 0..D {
+                let half_width = half * self.boundary.width[d];
+                width[d] = half_width;
+                corner[d] = if (i >> d) & 1 == 1 {
+                    self.boundary.corner[d] - half_width
+                } else {
+                    self.boundary.corner[d] + half_width
+                };
+            }
+            self.children
+                .push(SPTree::new_empty(self.data, corner, width));
+        }
+    }
+
+    /// Aggregates the centre of mass from the children, weighted by cumulative size and summed in
+    /// index order, so the result does not depend on the parallel build order.
+    fn combine_center_of_mass(&mut self) {
+        let center_of_mass = &mut self.center_of_mass;
+        *center_of_mass = [T::zero(); D];
+        let mut total = T::zero();
+        for child in self.children.iter() {
+            if child.cumulative_size == 0 {
+                continue;
+            }
+            let weight = T::from(child.cumulative_size).unwrap();
+            total += weight;
+            center_of_mass
+                .iter_mut()
+                .zip(child.center_of_mass.iter())
+                .for_each(|(center, &child_center)| *center += child_center * weight);
+        }
+        if total > T::zero() {
+            center_of_mass
+                .iter_mut()
+                .for_each(|center| *center /= total);
+        }
+    }
+
+    /// Whether every stored point lies inside the cell that holds it.
+    pub(crate) fn is_correct(&self) -> bool {
+        let is_correct = match self.index {
+            Some(index) => self.boundary.contains_point(self.point(index)),
+            None => true,
+        };
         if !self.is_leaf && is_correct {
-            // There are no children who are not correct.
             !self.children.iter().any(|child| !child.is_correct())
         } else {
             is_correct
         }
     }
 
-    /// Compute non-edge forces using Barnes-Hut algorithm.
-    ///
-    /// # Arguments
-    ///
-    /// * `index` - index of a point.
-    ///
-    /// * `theta` - parameter specific to Barnes-Hut algorithm.
-    ///
-    /// * `negative_forces_row` - negative forces.
-    ///
-    /// * `forces_buffer` - buffer for the forces.
-    ///
-    /// * `q_sum` - cumulative sum for the multiplicative factors.
+    /// Whether every non-empty cell's centre of mass lies within its own boundary, allowing a
+    /// small slack for floating point error. A correct tree satisfies this because a cell's centre
+    /// of mass is a convex combination of the points it holds, all of which lie inside the cell. A
+    /// corrupted aggregation, such as counting an empty child as mass at the origin, violates it.
+    pub(crate) fn centers_of_mass_within_cells(&self) -> bool {
+        let within = self.cumulative_size == 0
+            || (0..D).all(|d| {
+                let slack =
+                    T::from(0.01).unwrap() * self.boundary.width[d] + T::min_positive_value();
+                let low = self.boundary.corner[d] - self.boundary.width[d] - slack;
+                let high = self.boundary.corner[d] + self.boundary.width[d] + slack;
+                self.center_of_mass[d] >= low && self.center_of_mass[d] <= high
+            });
+        within
+            && self
+                .children
+                .iter()
+                .all(|child| child.centers_of_mass_within_cells())
+    }
+
+    /// Accumulates the non-edge (repulsive) Barnes-Hut forces on point `index` into
+    /// `negative_forces_row` and the normalization term `q_sum`. `forces_buffer` is scratch.
     pub(crate) fn compute_non_edge_forces(
         &self,
         index: usize,
         theta: T,
-        negative_forces_row: &mut [T],
-        forces_buffer: &mut [T],
+        negative_forces_row: &mut [T; D],
+        forces_buffer: &mut [T; D],
         q_sum: &mut T,
     ) {
-        // Make sure that  no time is spent on empty nodes or self-interactions.
+        // Skip empty nodes and self-interaction.
         if self.cumulative_size == 0
             || (self.is_leaf && self.index.map(|i| i == index).unwrap_or_default())
         {
             return;
         }
 
-        debug_assert_eq!(negative_forces_row.len(), forces_buffer.len());
+        let point = self.point(index);
 
-        // Retrieves point slice.
-        let point: &[T] = &self.data[index * self.dimension..(index + 1) * self.dimension];
-
-        // Compute distance between point and center-of-mass.
+        // Displacement to the centre of mass, and its squared length.
         forces_buffer
             .iter_mut()
             .zip(point.iter())
             .zip(self.center_of_mass.iter())
             .for_each(|((fb, &p), cm)| *fb = p - *cm);
-
         let mut distance: T = forces_buffer.iter().map(|b| b.powi(2)).sum();
 
-        // Check whether we can use this node as a summary.
         let max_width = self
             .boundary
             .width
@@ -325,20 +405,16 @@ where
             .fold(T::zero(), |acc, bw| if *bw >= acc { *bw } else { acc });
 
         if self.is_leaf || (max_width / distance.sqrt() < theta) {
-            // Compute and add tSNE forces between point and current node.
+            // Summarize the cell by its centre of mass.
             distance = T::one() / (T::one() + distance);
-
             let mut m: T = T::from(self.cumulative_size).unwrap() * distance;
-
             *q_sum += m;
             m *= distance;
-
             negative_forces_row
                 .iter_mut()
                 .zip(forces_buffer.iter())
                 .for_each(|(nf, b)| *nf += m * *b);
         } else {
-            // Recursively apply Barnes-Hut to children.
             self.children.iter().for_each(|child| {
                 child.compute_non_edge_forces(
                     index,
@@ -351,43 +427,20 @@ where
         }
     }
 
-    /// Computes edge forces.
-    ///
-    /// # Arguments
-    ///
-    /// * `index` = index of a sample.
-    ///
-    /// * `sample` - sample.
-    ///
-    /// * `p_rows` - row indices.
-    ///
-    /// * `p_columns` - column indices.
-    ///
-    /// * `p_values` - P matrix entries.
-    ///
-    /// * `n_samples` - number of points.
-    ///
-    /// * `positive_forces_row` - positive forces.
-    #[allow(clippy::too_many_arguments)]
+    /// Accumulates the edge (attractive) forces on point `index` from its sparse P matrix neighbors
+    /// into `positive_forces_row`. `forces_buffer` is scratch.
     pub(crate) fn compute_edge_forces(
         &self,
         index: usize,
-        sample: &[T],
         p_rows: &[usize],
         p_columns: &[usize],
         p_values: &[T],
-        forces_buffer: &mut [T],
-        positive_forces_row: &mut [T],
+        forces_buffer: &mut [T; D],
+        positive_forces_row: &mut [T; D],
     ) {
-        // Indexes neighbors of sample.
-        // index is the index of the sample.
+        let sample = self.point(index);
         for i in p_rows[index]..p_rows[index + 1] {
-            // Compute pairwise distance and Q-value.
-            let other_sample =
-                &self.data[p_columns[i] * self.dimension..(p_columns[i] + 1) * self.dimension];
-
-            debug_assert_eq!(sample.len(), other_sample.len(),);
-            debug_assert_eq!(forces_buffer.len(), positive_forces_row.len());
+            let other_sample = self.point(p_columns[i]);
 
             forces_buffer
                 .iter_mut()
@@ -398,7 +451,6 @@ where
             let mut distance = forces_buffer.iter().map(|fb| fb.powi(2)).sum::<T>();
             distance = p_values[i] / (distance + T::one());
 
-            // Sum positive force.
             positive_forces_row
                 .iter_mut()
                 .zip(forces_buffer.iter())


### PR DESCRIPTION
Every Barnes-Hut epoch rebuilds a space-partitioning tree from the embedding, and that rebuild, done by sequential point insertion, was the largest single cost in the loop (around 45% of an epoch at 2000 points, near half at 4000). It is pure serial work, so it capped the loop's speedup regardless of core count. Each epoch also ran five separate parallel passes with a serial zero-mean accumulation among them, so the per-epoch barrier count further limited scaling and is expensive under WASM's barrier model.

The tree is now built top-down in parallel: each cell partitions its points among its children, which are built on the pool. The structure is unchanged, because which cell a point lands in depends only on its position, not on insertion order. The per-epoch passes are fused from five to three, and the reductions are deterministic. The interesting part, and the reason for the const generic, is what blocked scaling on the first attempt: the parallel build barely reached 2x and then degraded past 8 threads. It was not load imbalance (uniform and clustered inputs scaled identically) but allocator contention from the per-cell `corner`, `width`, and `center_of_mass` `Vec`s, thousands of tiny allocations per build contending across threads. Making the embedding dimensionality a const generic `D` lets each cell store those inline as `[T; D]`, which removes the per-node allocation and unblocks the scaling.

The 100-epoch fit at 2000 points drops from 572ms to 149ms, about 4x, roughly 2.5x at 1000, and the gap widens with point count as the once-serial build scales. The fitting is also now deterministic across runs on the default multi-threaded pool, where the reductions previously accumulated in an order that depended on the thread schedule: the cross-path equality test no longer needs its single-thread pin, and a multi-threaded reproducibility test guards it. The one breaking change is that `embedding_dim()` is gone, the dimensionality is now the trailing const generic defaulting to 2, for example `tSNE::<f32, &[f32], 3>::new(..)`.

I had switched back the PR to draft mode because I had noticed a TSNE collapse in one of the dataset I am testing on downhill. Fixed it, and added a regression test.

<img width="1415" height="563" alt="image" src="https://github.com/user-attachments/assets/ce6483d1-a61e-4d5b-862e-3d5dce394167" />

And here's the preliminary visualization tests that now run in multi-threading in-browser, I hope to be able to publish it later this week:

<img width="400" height="360" alt="example" src="https://github.com/user-attachments/assets/6b63b9ca-d4c3-448e-be71-c50bac51b02e" />
