### PR TITLE
Add performance improvements

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,7 +15,7 @@ license = "MIT"
 name = "bhtsne"
 readme = "README.md"
 repository = "https://github.com/frjnn/bhtsne"
-version = "0.7.0"
+version = "0.7.1"
 
 [features]
 default = ["csv"]

--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@ Additional implementations of the algorithm, including this one, are listed at [
 Add this line to your `Cargo.toml`:
 ```toml
 [dependencies]
-bhtsne = "0.7.0"
+bhtsne = "0.7.1"
 ```
 ### Documentation
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -75,6 +75,10 @@ use rayon::{
     slice::{ParallelSlice, ParallelSliceMut},
 };
 
+/// Minimum sample count before the Barnes-Hut per-epoch light passes (the fused gradient update and
+/// the zero-mean recentering) fan out across the thread pool.
+const PARALLEL_CODE_THRESHOLD: usize = 4096;
+
 /// Boxed closure invoked at the end of each fitting epoch with the epoch index and a
 /// snapshot of the current embedding. See [`tSNE::epoch_callback`].
 ///
@@ -89,6 +93,12 @@ enum Fit<T> {
     Exact,
     BarnesHut { theta: T },
 }
+
+/// Used by the fused update.
+type UpdateRow<'a, T> = (
+    (((&'a mut [T], &'a [T]), &'a [T]), &'a mut [T]),
+    &'a mut [T],
+);
 
 /// A sample's nearest neighbor for [`tSNE::barnes_hut_with_neighbors`]: its index
 /// and the distance (not a similarity) to it.
@@ -503,6 +513,9 @@ where
 
             // Computes the exact gradient in parallel.
             let q_values_sum: T = self.q_values.par_iter().copied().sum::<T>();
+            // Precompute the reciprocal so the n^2 inner gradient terms multiply by it instead of
+            // each dividing by the same sum, mirroring the Barnes-Hut path's `inverse_q_sum`.
+            let inverse_q_sum = q_values_sum.recip();
 
             // Immutable borrow to self must happen outside of the inner sequential
             // loop. The outer parallel loop already has a mutable borrow.
@@ -522,7 +535,7 @@ where
                             .zip(y.chunks(D))
                             .for_each(|((&p, &q), other_sample)| {
                                 let other_sample: &[T; D] = other_sample.try_into().unwrap();
-                                let m: T = (p - q / q_values_sum) * q;
+                                let m: T = (p - q * inverse_q_sum) * q;
                                 dy_sample
                                     .iter_mut()
                                     .zip(y_sample.iter())
@@ -847,33 +860,33 @@ where
             let min_gain = T::from(0.01).unwrap();
             self.y
                 .par_chunks_mut(D)
+                .with_min_len(PARALLEL_CODE_THRESHOLD)
                 .zip(positive_forces.par_chunks(D))
                 .zip(negative_forces.par_chunks(D))
                 .zip(self.uy.par_chunks_mut(D))
                 .zip(self.gains.par_chunks_mut(D))
-                .for_each(
-                    |((((y_sample, positive), negative), uy_sample), gains_sample)| {
-                        y_sample
-                            .iter_mut()
-                            .zip(positive.iter())
-                            .zip(negative.iter())
-                            .zip(uy_sample.iter_mut())
-                            .zip(gains_sample.iter_mut())
-                            .for_each(|((((y_el, pf), nf), uy_el), gain)| {
-                                let gradient = *pf - *nf * inverse_q_sum;
-                                *gain = if gradient.signum() != uy_el.signum() {
-                                    *gain + gain_increment
-                                } else {
-                                    *gain * gain_decay
-                                };
-                                if *gain < min_gain {
-                                    *gain = min_gain;
-                                }
-                                *uy_el = momentum * *uy_el - learning_rate * *gain * gradient;
-                                *y_el += *uy_el;
-                            });
-                    },
-                );
+                .for_each(|row: UpdateRow<'_, T>| {
+                    let ((((y_sample, positive), negative), uy_sample), gains_sample) = row;
+                    y_sample
+                        .iter_mut()
+                        .zip(positive.iter())
+                        .zip(negative.iter())
+                        .zip(uy_sample.iter_mut())
+                        .zip(gains_sample.iter_mut())
+                        .for_each(|((((y_el, pf), nf), uy_el), gain)| {
+                            let gradient = *pf - *nf * inverse_q_sum;
+                            *gain = if gradient.signum() != uy_el.signum() {
+                                *gain + gain_increment
+                            } else {
+                                *gain * gain_decay
+                            };
+                            if *gain < min_gain {
+                                *gain = min_gain;
+                            }
+                            *uy_el = momentum * *uy_el - learning_rate * *gain * gradient;
+                            *y_el += *uy_el;
+                        });
+                });
 
             // Recenter (zero mean). The per-dimension sums accumulate sequentially (barrier-free),
             // so only the subtraction is a parallel pass.
@@ -884,14 +897,17 @@ where
                     .zip(sample.iter())
                     .for_each(|(mean, &value)| *mean += value);
             });
-            let n = T::from(n_samples).unwrap();
-            means.iter_mut().for_each(|mean| *mean /= n);
-            self.y.par_chunks_mut(D).for_each(|sample| {
-                sample
-                    .iter_mut()
-                    .zip(means.iter())
-                    .for_each(|(value, &mean)| *value -= mean);
-            });
+            let den = T::from(n_samples).unwrap().recip();
+            means.iter_mut().for_each(|mean| *mean *= den);
+            self.y
+                .par_chunks_mut(D)
+                .with_min_len(PARALLEL_CODE_THRESHOLD)
+                .for_each(|sample| {
+                    sample
+                        .iter_mut()
+                        .zip(means.iter())
+                        .for_each(|(value, &mean)| *value -= mean);
+                });
 
             self.epoch_tail(epoch, &mut epoch_callback, &mut snapshot);
         }

--- a/src/tsne/arena.rs
+++ b/src/tsne/arena.rs
@@ -13,16 +13,15 @@
 use std::ops::AddAssign;
 
 use num_traits::Float;
+
 use rayon::prelude::*;
+
+use crate::PARALLEL_CODE_THRESHOLD;
 
 use super::morton::{Dim, Morton, quantize};
 
 /// `first_child` value marking a leaf, a node with no children in the arena.
 const SENTINEL: u32 = u32::MAX;
-
-/// Minimum chunk length for the parallel bounding-box and code passes, so small inputs are not
-/// split across the thread pool only to pay its overhead.
-const PARALLEL_CODE_THRESHOLD: usize = 4096;
 
 /// Capacity of the traversal stack. A root-to-leaf path crosses at most `BITS` internal cells (a
 /// child's level is strictly greater than its parent's), and each pushes at most `2^D - 1`
@@ -154,9 +153,12 @@ where
 
         // 5. Breadth-first emission: each node's children (the non-empty orthant groups at the
         // node's tightest enclosing level) occupy a contiguous arena range. `ranges` carries each
-        // node's window in `sorted` and is build scratch only.
-        let mut nodes: Vec<Node<T, D>> = Vec::new();
-        let mut ranges: Vec<(u32, u32)> = Vec::new();
+        // node's window in `sorted` and is build scratch only. Every internal node has at least two
+        // children (single-child chains are skipped by the tightest-enclosing-level jump), so an
+        // arena over `n` points holds at most `2n - 1` nodes; reserving that up front lets the
+        // sequential emission push without reallocating as it grows, every epoch.
+        let mut nodes: Vec<Node<T, D>> = Vec::with_capacity(2 * n_samples - 1);
+        let mut ranges: Vec<(u32, u32)> = Vec::with_capacity(2 * n_samples - 1);
         nodes.push(Node {
             center_of_mass: [T::zero(); D],
             count: n_samples as u32,
@@ -219,6 +221,7 @@ where
         nodes
             .par_iter_mut()
             .zip(ranges.par_iter())
+            .with_min_len(PARALLEL_CODE_THRESHOLD)
             .for_each(|(node, &(start, end))| {
                 if node.first_child == SENTINEL {
                     let mut center = [T::zero(); D];

--- a/src/tsne/mod.rs
+++ b/src/tsne/mod.rs
@@ -147,19 +147,15 @@ pub(super) fn compute_pairwise_distance_matrix<'a, T, U, F, G>(
     F: Fn(&U, &U) -> T + Sync + Send,
     G: Fn(&usize) -> &'a U + Sync + Send,
 {
+    // Parallelize over rows and compute only the upper triangular entries, excluding the diagonal.
     distances
-        .par_iter_mut()
+        .par_chunks_mut(n_samples)
         .enumerate()
-        .map(|(index, d)| {
-            // Picks upper triangular entries excluding the diagonal ones.
-            let row_index = index / n_samples;
-            let column_index = index % n_samples;
-
-            (row_index, column_index, d)
-        })
-        .filter(|(row_index, column_index, _)| row_index < column_index)
-        .for_each(|(i, j, d)| {
-            *d = f(g(&i), g(&j));
+        .for_each(|(i, distances_row)| {
+            let ith = g(&i);
+            for (j, d) in distances_row.iter_mut().enumerate().skip(i + 1) {
+                *d = f(ith, g(&j));
+            }
         });
 
     // Symmetrizes the matrix. Effectively filling it.
@@ -202,7 +198,7 @@ where
             .iter_mut()
             .zip(distances_row.iter())
             .for_each(|(p, d)| {
-                *p = (-beta * d.powi(2)).exp();
+                *p = (-beta * (*d * *d)).exp();
             });
 
         // After that the row is normalized.
@@ -213,7 +209,7 @@ where
         let mut entropy = p_values_row
             .iter()
             .zip(distances_row.iter())
-            .fold(T::zero(), |acc, (p, d)| acc + beta * *p * d.powi(2));
+            .fold(T::zero(), |acc, (p, d)| acc + beta * *p * (*d * *d));
         entropy = entropy / p_values_row_sum + p_values_row_sum.ln();
 
         // It evaluates whether the entropy is within the tolerance level.

--- a/src/tsne/morton.rs
+++ b/src/tsne/morton.rs
@@ -33,6 +33,7 @@ pub struct Dim<const D: usize>;
 
 /// Spreads the low 32 bits of `x` into the even bit positions (one zero gap between each), the
 /// 2D Morton building block.
+#[inline]
 fn part_1by1(mut x: u64) -> u64 {
     x &= 0x0000_0000_ffff_ffff;
     x = (x | (x << 16)) & 0x0000_ffff_0000_ffff;
@@ -43,6 +44,7 @@ fn part_1by1(mut x: u64) -> u64 {
 }
 
 /// Inverse of [`part_1by1`]: gathers the even bit positions back into the low 32 bits.
+#[inline]
 fn compact_1by1(mut x: u64) -> u64 {
     x &= 0x5555_5555_5555_5555;
     x = (x | (x >> 1)) & 0x3333_3333_3333_3333;
@@ -53,6 +55,7 @@ fn compact_1by1(mut x: u64) -> u64 {
 }
 
 /// Spreads the low 21 bits of `x` so each lands three positions apart, the 3D Morton building block.
+#[inline]
 fn part_1by2(mut x: u64) -> u64 {
     x &= 0x1f_ffff;
     x = (x | (x << 32)) & 0x001f_0000_0000_ffff;
@@ -63,6 +66,7 @@ fn part_1by2(mut x: u64) -> u64 {
 }
 
 /// Inverse of [`part_1by2`]: gathers every third bit back into the low 21 bits.
+#[inline]
 fn compact_1by2(mut x: u64) -> u64 {
     x &= 0x1249_2492_4924_9249;
     x = (x | (x >> 2)) & 0x10c3_0c30_c30c_30c3;
@@ -76,8 +80,8 @@ impl Morton<2> for Dim<2> {
     const CHILDREN: usize = 4;
     const BITS: u32 = 32;
 
-    fn encode(coords: [u32; 2]) -> u64 {
-        part_1by1(coords[0] as u64) | (part_1by1(coords[1] as u64) << 1)
+    fn encode([c0, c1]: [u32; 2]) -> u64 {
+        part_1by1(c0 as u64) | (part_1by1(c1 as u64) << 1)
     }
 
     fn decode(code: u64) -> [u32; 2] {
@@ -89,10 +93,8 @@ impl Morton<3> for Dim<3> {
     const CHILDREN: usize = 8;
     const BITS: u32 = 21;
 
-    fn encode(coords: [u32; 3]) -> u64 {
-        part_1by2(coords[0] as u64)
-            | (part_1by2(coords[1] as u64) << 1)
-            | (part_1by2(coords[2] as u64) << 2)
+    fn encode([c0, c1, c2]: [u32; 3]) -> u64 {
+        part_1by2(c0 as u64) | (part_1by2(c1 as u64) << 1) | (part_1by2(c2 as u64) << 2)
     }
 
     fn decode(code: u64) -> [u32; 3] {


### PR DESCRIPTION
Benches against current master:

```
Compiling bhtsne v0.7.0 (/Users/francesco/Documents/bhtsne)
    Finished `bench` profile [optimized] target(s) in 1.89s
     Running benches/tsne.rs (target/release/deps/tsne-664b049fe64f41f6)
tsne_exact/f32/n250/0   time:   [840.48 µs 842.62 µs 845.33 µs]
                        change: [−6.0875% −5.6215% −5.1811%] (p = 0.00 < 0.05)
                        Performance has improved.
tsne_exact/f32/n250/100 time:   [45.419 ms 45.577 ms 45.741 ms]
                        change: [−11.857% −10.980% −10.217%] (p = 0.00 < 0.05)
                        Performance has improved.
tsne_exact/f32/n500/0   time:   [2.6382 ms 2.6436 ms 2.6526 ms]
                        change: [−2.9464% −2.3544% −1.8019%] (p = 0.00 < 0.05)
                        Performance has improved.
Found 1 outliers among 10 measurements (10.00%)
  1 (10.00%) high mild
tsne_exact/f32/n500/100 time:   [78.048 ms 78.155 ms 78.250 ms]
                        change: [−6.2936% −5.7691% −5.1413%] (p = 0.00 < 0.05)
                        Performance has improved.
Found 2 outliers among 10 measurements (20.00%)
  1 (10.00%) low mild
  1 (10.00%) high severe
tsne_exact/f64/n250/0   time:   [1.0328 ms 1.0352 ms 1.0372 ms]
                        change: [−4.5845% −4.1911% −3.6946%] (p = 0.00 < 0.05)
                        Performance has improved.
Found 1 outliers among 10 measurements (10.00%)
  1 (10.00%) high severe
tsne_exact/f64/n250/100 time:   [47.874 ms 48.076 ms 48.249 ms]
                        change: [−8.0413% −7.4202% −6.7746%] (p = 0.00 < 0.05)
                        Performance has improved.
Found 1 outliers among 10 measurements (10.00%)
  1 (10.00%) high severe
tsne_exact/f64/n500/0   time:   [3.2676 ms 3.2951 ms 3.3226 ms]
                        change: [−1.6795% −1.2248% −0.6543%] (p = 0.00 < 0.05)
                        Change within noise threshold.
Found 1 outliers among 10 measurements (10.00%)
  1 (10.00%) high mild
tsne_exact/f64/n500/100 time:   [78.915 ms 79.191 ms 79.408 ms]
                        change: [−10.448% −9.7997% −9.1246%] (p = 0.00 < 0.05)
                        Performance has improved.
Found 2 outliers among 10 measurements (20.00%)
  1 (10.00%) low mild
  1 (10.00%) high severe

tsne_barnes_hut/f32/n1000/0
                        time:   [7.5319 ms 7.5391 ms 7.5448 ms]
                        change: [−1.5087% −0.8223% −0.1651%] (p = 0.03 < 0.05)
                        Change within noise threshold.
Found 1 outliers among 10 measurements (10.00%)
  1 (10.00%) high severe
tsne_barnes_hut/f32/n1000/100
                        time:   [41.620 ms 41.802 ms 41.992 ms]
                        change: [−25.769% −24.504% −23.249%] (p = 0.00 < 0.05)
                        Performance has improved.
tsne_barnes_hut/f32/n2000/0
                        time:   [14.417 ms 14.440 ms 14.483 ms]
                        change: [−2.5195% −1.7374% −0.8475%] (p = 0.00 < 0.05)
                        Change within noise threshold.
Found 1 outliers among 10 measurements (10.00%)
  1 (10.00%) high severe
tsne_barnes_hut/f32/n2000/100
                        time:   [65.665 ms 67.129 ms 68.427 ms]
                        change: [−23.442% −21.255% −19.287%] (p = 0.00 < 0.05)
                        Performance has improved.
tsne_barnes_hut/f64/n1000/0
                        time:   [8.0398 ms 8.0891 ms 8.1437 ms]
                        change: [+1.0689% +2.0400% +2.9923%] (p = 0.00 < 0.05)
                        Performance has regressed.
Found 1 outliers among 10 measurements (10.00%)
  1 (10.00%) high mild
tsne_barnes_hut/f64/n1000/100
                        time:   [41.479 ms 42.076 ms 42.714 ms]
                        change: [−26.174% −24.931% −23.687%] (p = 0.00 < 0.05)
                        Performance has improved.
tsne_barnes_hut/f64/n2000/0
                        time:   [15.610 ms 15.689 ms 15.811 ms]
                        change: [−0.5307% +0.3563% +1.1884%] (p = 0.46 > 0.05)
                        No change in performance detected.
Found 2 outliers among 10 measurements (20.00%)
  1 (10.00%) low mild
  1 (10.00%) high mild
tsne_barnes_hut/f64/n2000/100
                        time:   [79.086 ms 84.378 ms 89.661 ms]
                        change: [−21.457% −14.124% −6.9135%] (p = 0.00 < 0.05)
                        Performance has improved.
```
cc. @LucaCappelletti94 