### PR TITLE
Expose the early exaggeration factor as a settable knob

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -123,6 +123,7 @@ where
     final_momentum: T,
     momentum_switch_epoch: usize,
     stop_lying_epoch: usize,
+    early_exaggeration: T,
     perplexity: T,
     p_values: Vec<T>,
     p_rows: Vec<usize>,
@@ -164,6 +165,7 @@ where
     /// * `momentum = 0.5`
     /// * `final_momentum = 0.8`
     /// * `stop_lying_epoch = 250`
+    /// * `early_exaggeration = 12.0`
     /// * embedding space dimensionality `D = 2` (the trailing const generic of [`tSNE`])
     /// * `perplexity = 20.0`
     /// * `random_init = false`
@@ -208,6 +210,7 @@ where
             final_momentum: T::from(0.8).unwrap(),
             momentum_switch_epoch: 250,
             stop_lying_epoch: 250,
+            early_exaggeration: T::from(12.0).unwrap(),
             perplexity: T::from(20.0).unwrap(),
             p_values: Vec::new(),
             p_rows: Vec::new(),
@@ -281,7 +284,7 @@ where
 
     /// Sets a new stop lying epoch, i.e. the epoch after which the P distribution values become
     /// true, as defined in the original implementation. For epochs < `stop_lying_epoch` the values
-    /// of the P distribution are multiplied by a factor equal to `12.0`.
+    /// of the P distribution are multiplied by the `early_exaggeration` factor (`12.0` by default).
     ///
     /// A value of `0` disables the early exaggeration entirely, useful when warm starting from an
     /// already converged embedding.
@@ -291,6 +294,20 @@ where
     /// `stop_lying_epoch` - new value for the stop lying epoch.
     pub fn stop_lying_epoch(&mut self, stop_lying_epoch: usize) -> &mut Self {
         self.stop_lying_epoch = stop_lying_epoch;
+
+        self
+    }
+
+    /// Sets the early exaggeration factor, the multiplier applied to the `P`
+    /// distribution for epochs before `stop_lying_epoch`. Larger values push
+    /// clusters further apart early on. The original recipe uses `12.0`. A value
+    /// of `1.0` disables exaggeration (equivalent to `stop_lying_epoch(0)`).
+    ///
+    /// # Arguments
+    ///
+    /// `early_exaggeration` - new value for the early exaggeration factor.
+    pub fn early_exaggeration(&mut self, early_exaggeration: T) -> &mut Self {
+        self.early_exaggeration = early_exaggeration;
 
         self
     }
@@ -578,10 +595,10 @@ where
     /// embedding. Shared by `exact` and `barnes_hut_fit`.
     fn finalize_p_and_seed(&mut self, grad_entries: usize) {
         // Normalize P values.
-        tsne::normalize_p_values(&mut self.p_values);
+        tsne::normalize_p_values(&mut self.p_values, self.early_exaggeration);
         // With no early exaggeration phase, undo the lying immediately.
         if self.stop_lying_epoch == 0 {
-            tsne::stop_lying(&mut self.p_values);
+            tsne::stop_lying(&mut self.p_values, self.early_exaggeration);
         }
 
         // Seed from the supplied embedding if any, otherwise initialize randomly.
@@ -960,7 +977,7 @@ where
         snapshot: &mut [T],
     ) {
         if epoch == self.stop_lying_epoch && epoch != 0 {
-            tsne::stop_lying(&mut self.p_values);
+            tsne::stop_lying(&mut self.p_values, self.early_exaggeration);
         }
         if epoch == self.momentum_switch_epoch {
             self.momentum = self.final_momentum;

--- a/src/test.rs
+++ b/src/test.rs
@@ -49,6 +49,19 @@ fn set_stop_lying_epoch() {
 }
 
 #[test]
+fn set_early_exaggeration() {
+    let mut tsne: tSNE<f32, f32> = tSNE::new(&[0.]);
+    tsne.early_exaggeration(4.);
+    assert_eq!(tsne.early_exaggeration, 4.);
+}
+
+#[test]
+fn early_exaggeration_default_is_twelve() {
+    let tsne: tSNE<f32, f32> = tSNE::new(&[0.]);
+    assert_eq!(tsne.early_exaggeration, 12.);
+}
+
+#[test]
 fn set_perplexity() {
     let mut tsne: tSNE<f32, f32> = tSNE::new(&[0.]);
     tsne.perplexity(15.);
@@ -445,6 +458,107 @@ fn warm_start_begins_from_initial_embedding_exact() {
     assert!(
         random_displacement > 10.0 * displacement,
         "warm start indistinguishable from a random initialization: {displacement} against {random_displacement}"
+    );
+}
+
+/// Exact squared-euclidean distance used by the early-exaggeration fits below.
+fn squared_euclidean(a: &[f32], b: &[f32]) -> f32 {
+    a.iter().zip(b.iter()).map(|(x, y)| (x - y).powi(2)).sum()
+}
+
+/// Runs a short exact fit from a fixed seed and returns the embedding snapshot at
+/// the end of epoch `capture`, so two configurations can be compared at the same
+/// point of the optimization. `configure` sets the knob under test.
+fn exact_snapshot_at<F>(capture: usize, configure: F) -> Vec<f32>
+where
+    F: FnOnce(&mut tSNE<'_, f32, &[f32]>),
+{
+    const N: usize = 60;
+    const DIM: usize = 4;
+
+    let data = lcg_samples(N, DIM, 7);
+    let samples: Vec<&[f32]> = data.chunks(DIM).collect();
+    let seed = lcg_samples(N, NO_DIMS as usize, 99);
+
+    let mut snapshot: Vec<f32> = Vec::new();
+    {
+        let mut tsne: tSNE<f32, &[f32]> = tSNE::new(&samples);
+        tsne.perplexity(PERPLEXITY)
+            .epochs(capture + 1)
+            .initial_embedding(&seed[..]);
+        configure(&mut tsne);
+        tsne.epoch_callback(|epoch, current| {
+            if epoch == capture {
+                snapshot.extend_from_slice(current);
+            }
+        })
+        .exact(|a, b| squared_euclidean(a, b));
+    }
+    snapshot
+}
+
+/// Setting the factor to its default `12.0` explicitly must match leaving it
+/// unset, so existing callers see no behavior change. The two runs execute the
+/// same arithmetic, so they may differ only by parallel-reduction noise, far
+/// below the embedding scale.
+#[test]
+fn early_exaggeration_explicit_twelve_matches_default() {
+    // Compare after a single step: the optimizer is chaotic, so even identical
+    // arithmetic diverges macroscopically over many epochs once parallel-reduction
+    // noise is amplified. One step isolates the behavior from that amplification.
+    let default_run = exact_snapshot_at(0, |_tsne| {});
+    let explicit_run = exact_snapshot_at(0, |tsne| {
+        tsne.early_exaggeration(12.0);
+    });
+
+    let dim = NO_DIMS as usize;
+    let drift = mean_point_distance(&default_run, &explicit_run, dim);
+    let diagonal = bounding_box_diagonal(&default_run, dim);
+    assert!(
+        drift <= 1e-4 * diagonal + 1e-6,
+        "explicit 12.0 strayed {drift} from the default, diagonal {diagonal}"
+    );
+}
+
+/// The factor must reach the optimizer: two fits differing only in
+/// `early_exaggeration` pull the embedding apart by different amounts in the
+/// early epochs, so their first-epoch snapshots are measurably different.
+#[test]
+fn early_exaggeration_changes_early_embedding() {
+    let strong = exact_snapshot_at(0, |tsne| {
+        tsne.early_exaggeration(12.0);
+    });
+    let weak = exact_snapshot_at(0, |tsne| {
+        tsne.early_exaggeration(4.0);
+    });
+
+    let dim = NO_DIMS as usize;
+    let difference = mean_point_distance(&strong, &weak, dim);
+    let diagonal = bounding_box_diagonal(&strong, dim);
+    assert!(
+        difference > 0.05 * diagonal,
+        "exaggeration 12.0 against 4.0 barely moved the first epoch: {difference} against diagonal {diagonal}"
+    );
+}
+
+/// `early_exaggeration(1.0)` is a second way to express "no exaggeration": it must
+/// produce the same first epoch as `stop_lying_epoch(0)`, which normalizes then
+/// undoes the lying immediately. Both leave the `P` distribution unexaggerated.
+#[test]
+fn early_exaggeration_one_matches_stop_lying_zero() {
+    let no_exaggeration = exact_snapshot_at(0, |tsne| {
+        tsne.early_exaggeration(1.0);
+    });
+    let lying_disabled = exact_snapshot_at(0, |tsne| {
+        tsne.stop_lying_epoch(0);
+    });
+
+    let dim = NO_DIMS as usize;
+    let drift = mean_point_distance(&no_exaggeration, &lying_disabled, dim);
+    let diagonal = bounding_box_diagonal(&no_exaggeration, dim);
+    assert!(
+        drift <= 1e-4 * diagonal + 1e-6,
+        "the two no-exaggeration paths diverged: {drift} against diagonal {diagonal}"
     );
 }
 

--- a/src/tsne/mod.rs
+++ b/src/tsne/mod.rs
@@ -256,12 +256,17 @@ where
 ///
 /// # Arguments
 ///
-/// `p_values` - values of the P distribution.
-pub(super) fn normalize_p_values<T: Float + Send + Sync + MulAssign + Sum>(p_values: &mut [T]) {
+/// * `p_values` - values of the P distribution.
+///
+/// * `early_exaggeration` - factor the P distribution is multiplied by during the early phase.
+pub(super) fn normalize_p_values<T: Float + Send + Sync + MulAssign + Sum>(
+    p_values: &mut [T],
+    early_exaggeration: T,
+) {
     let p_values_sum: T = p_values.par_iter().copied().sum::<T>();
     // Fold the normalization and the early-exaggeration factor into one reciprocal, so the hot pass
     // is a single multiply per value rather than a divide and a multiply.
-    let scale = T::from(12.0).unwrap() / (p_values_sum + T::epsilon());
+    let scale = early_exaggeration / (p_values_sum + T::epsilon());
     p_values.par_iter_mut().for_each(|p| *p *= scale);
 }
 
@@ -414,9 +419,14 @@ pub(super) fn update_solution<T>(
 ///
 /// # Arguments
 ///
-/// `p_values` - P distribution.
-pub(super) fn stop_lying<T: Float + Send + Sync + MulAssign>(p_values: &mut [T]) {
-    let scale = T::one() / T::from(12.0).unwrap();
+/// * `p_values` - P distribution.
+///
+/// * `early_exaggeration` - factor the early phase multiplied the P distribution by, undone here.
+pub(super) fn stop_lying<T: Float + Send + Sync + MulAssign>(
+    p_values: &mut [T],
+    early_exaggeration: T,
+) {
+    let scale = T::one() / early_exaggeration;
     p_values.par_iter_mut().for_each(|p| *p *= scale);
 }
 


### PR DESCRIPTION
The early exaggeration factor, the multiplier applied to the `P` distribution during the epochs before `stop_lying_epoch`, was hardcoded to `12.0` in `normalize_p_values` and `stop_lying`. This exposes it through an `early_exaggeration` builder, matching `scikit-learn` and `openTSNE`. The default stays `12.0`, so callers that never set it see no change, and `early_exaggeration(1.0)` becomes a second way to express no exaggeration alongside `stop_lying_epoch(0)`. It also makes the factor available as the denominator of a size-scaled learning rate, which is the follow-up change.