### PR TITLE
Default the learning rate to the size-scaled auto value

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -117,7 +117,7 @@ where
     U: Send + Sync,
 {
     data: &'data [U],
-    learning_rate: T,
+    learning_rate: Option<T>,
     epochs: usize,
     momentum: T,
     final_momentum: T,
@@ -160,7 +160,7 @@ where
     /// According to the original implementation, the following configuration is provided by
     /// default:
     ///
-    /// * `learning_rate = 200`
+    /// * `learning_rate = auto` (`max(n_samples / early_exaggeration / 4, 50)`)
     /// * `epochs = 1000`
     /// * `momentum = 0.5`
     /// * `final_momentum = 0.8`
@@ -204,7 +204,7 @@ where
     pub fn new(data: &'data [U]) -> Self {
         Self {
             data,
-            learning_rate: T::from(200.0).unwrap(),
+            learning_rate: None,
             epochs: 1000,
             momentum: T::from(0.5).unwrap(),
             final_momentum: T::from(0.8).unwrap(),
@@ -226,13 +226,17 @@ where
         }
     }
 
-    /// Sets a new learning rate.
+    /// Sets an explicit learning rate, overriding the size-scaled default.
+    ///
+    /// When left unset the learning rate defaults to
+    /// `max(n_samples / early_exaggeration / 4, 50)`, following scikit-learn and
+    /// openTSNE, which adapts the step size to the dataset.
     ///
     /// # Arguments
     ///
     /// `learning_rate` - new value for the learning rate.
     pub fn learning_rate(&mut self, learning_rate: T) -> &mut Self {
-        self.learning_rate = learning_rate;
+        self.learning_rate = Some(learning_rate);
 
         self
     }
@@ -503,6 +507,9 @@ where
         // Normalize P, disable the early exaggeration if requested, and seed the embedding.
         self.finalize_p_and_seed(grad_entries);
 
+        // Resolve the learning rate once: explicit if set, otherwise size-scaled.
+        let learning_rate = self.resolve_learning_rate(n_samples);
+
         // The callback is detached from self for the fit so the epoch loop is free
         // to borrow the other fields mutably; it is put back once the loop ends.
         let (mut epoch_callback, mut snapshot) = self.take_callback_and_snapshot(grad_entries);
@@ -570,7 +577,7 @@ where
                 &self.dy,
                 &mut self.uy,
                 &mut self.gains,
-                &self.learning_rate,
+                &learning_rate,
                 &self.momentum,
             );
 
@@ -589,6 +596,17 @@ where
         self.fit = Some(Fit::Exact);
 
         self
+    }
+
+    /// Resolves the learning rate: the explicit value if set, otherwise the
+    /// size-scaled `max(n_samples / early_exaggeration / 4, 50)` default, as used
+    /// by scikit-learn and openTSNE.
+    fn resolve_learning_rate(&self, n_samples: usize) -> T {
+        self.learning_rate.unwrap_or_else(|| {
+            let auto =
+                T::from(n_samples).unwrap() / self.early_exaggeration / T::from(4.0).unwrap();
+            auto.max(T::from(50.0).unwrap())
+        })
     }
 
     /// Normalizes P, undoes the early exaggeration if disabled, and seeds the
@@ -870,7 +888,7 @@ where
 
             // Fuse the gradient (`positive - negative * inverse_q_sum`) into the gradient-descent
             // update, so it needs no separate buffer or sweep.
-            let learning_rate = self.learning_rate;
+            let learning_rate = self.resolve_learning_rate(n_samples);
             let momentum = self.momentum;
             let gain_increment = T::from(0.2).unwrap();
             let gain_decay = T::from(0.8).unwrap();

--- a/src/test.rs
+++ b/src/test.rs
@@ -10,7 +10,58 @@ const NO_DIMS: u8 = 2;
 fn set_learning_rate() {
     let mut tsne: tSNE<f32, f32> = tSNE::new(&[0.]);
     tsne.learning_rate(15.);
-    assert_eq!(tsne.learning_rate, 15.);
+    assert_eq!(tsne.learning_rate, Some(15.));
+}
+
+#[test]
+fn learning_rate_defaults_to_unset() {
+    let tsne: tSNE<f32, f32> = tSNE::new(&[0.]);
+    assert_eq!(tsne.learning_rate, None);
+}
+
+#[test]
+fn auto_learning_rate_hits_the_floor_for_small_n() {
+    // 100 / 12 / 4 is about 2.08, well below the floor, so the rate clamps to 50.
+    let tsne: tSNE<f32, f32> = tSNE::new(&[0.]);
+    assert_eq!(tsne.resolve_learning_rate(100), 50.0);
+}
+
+#[test]
+fn auto_learning_rate_scales_with_n() {
+    // Above the floor the rate is exactly n / early_exaggeration / 4.
+    let tsne: tSNE<f32, f32> = tSNE::new(&[0.]);
+    assert_eq!(tsne.resolve_learning_rate(120_000), 120_000.0 / 12.0 / 4.0);
+}
+
+#[test]
+fn explicit_learning_rate_overrides_the_auto_default() {
+    let mut tsne: tSNE<f32, f32> = tSNE::new(&[0.]);
+    tsne.learning_rate(123.0);
+    assert_eq!(tsne.resolve_learning_rate(100), 123.0);
+    assert_eq!(tsne.resolve_learning_rate(1_000_000), 123.0);
+}
+
+#[test]
+fn auto_learning_rate_is_coupled_to_early_exaggeration() {
+    let mut tsne: tSNE<f32, f32> = tSNE::new(&[0.]);
+    let with_default = tsne.resolve_learning_rate(120_000);
+    tsne.early_exaggeration(6.0);
+    let with_half = tsne.resolve_learning_rate(120_000);
+    // Halving the exaggeration doubles the auto rate (both are above the floor).
+    assert_eq!(with_half, 2.0 * with_default);
+}
+
+/// Calibration guard: at n = 10000 with the default factor the auto rate lands
+/// near the historical fixed 200, confirming the divisor convention. A wrong
+/// divisor would move this far out of band.
+#[test]
+fn auto_learning_rate_matches_historical_default_at_ten_thousand() {
+    let tsne: tSNE<f32, f32> = tSNE::new(&[0.]);
+    let rate = tsne.resolve_learning_rate(10_000);
+    assert!(
+        (205.0..=212.0).contains(&rate),
+        "auto rate at n=10000 is {rate}, expected close to 208 (= 10000 / 12 / 4)"
+    );
 }
 
 #[test]


### PR DESCRIPTION
The default `learning_rate` of `200` is the original van der Maaten value, calibrated for a few thousand points, so for large `N` the embedding crawls. This makes the unset rate adaptive, `max(n_samples / early_exaggeration / 4, 50)`, the formula `scikit-learn` (since 0.22) and `openTSNE` use. An explicit `learning_rate(x)` still wins, so only the default behavior changes. It is continuous with the old default: small inputs land on the `50` floor, `n` near 10000 stays around `200` (10000 / 12 / 4 is about 208), and only large inputs scale up, which is exactly where the fixed value was too small. Builds on the `early_exaggeration` knob added in #34.