### PR TITLE
Reuse cached affinities only when custom neighbors match

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -672,7 +672,7 @@ where
         if self.has_cached_affinities(n_samples) {
             return self.run_cached_affinities(theta, n_samples);
         }
-        // No cached affinities or mismatched dataset — rebuild.
+        // No cached affinities or mismatched dataset, rebuild.
         let data = self.data;
         // Number of points to consider when approximating the conditional distribution P.
         let n_neighbors: usize = (T::from(3.0).unwrap() * self.perplexity).as_();

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -115,6 +115,7 @@ pub struct SparseAffinities<T> {
     rows: Vec<usize>,
     columns: Vec<u32>,
     values: Vec<T>,
+    perplexity: T,
 }
 
 /// t-distributed stochastic neighbor embedding. Provides a parallel implementation of both the
@@ -782,6 +783,7 @@ where
             rows: self.p_rows.clone(),
             columns: self.p_columns.clone(),
             values,
+            perplexity: self.perplexity,
         })
     }
 
@@ -790,6 +792,10 @@ where
     ///
     /// [`barnes_hut`]: tSNE::barnes_hut
     pub fn with_affinities(&mut self, affinities: SparseAffinities<T>) -> &mut Self {
+        assert!(
+            affinities.perplexity == self.perplexity,
+            "cached affinities were built with a different perplexity"
+        );
         self.p_rows = affinities.rows;
         self.p_columns = affinities.columns;
         self.p_values = affinities.values;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -145,6 +145,7 @@ where
     epoch_callback: Option<EpochCallback<'data, T>>,
     initial_embedding: Option<Vec<T>>,
     stop_lying_fired: bool,
+    cached_perplexity: Option<T>,
     fit: Option<Fit<T>>,
 }
 
@@ -233,6 +234,7 @@ where
             epoch_callback: None,
             initial_embedding: None,
             stop_lying_fired: false,
+            cached_perplexity: None,
             fit: None,
         }
     }
@@ -791,6 +793,7 @@ where
         self.p_rows = affinities.rows;
         self.p_columns = affinities.columns;
         self.p_values = affinities.values;
+        self.cached_perplexity = Some(self.perplexity);
         self
     }
     /// writes sample `index`'s neighbor indices and distances; the rest is common.
@@ -856,6 +859,9 @@ where
             n_samples,
             &n_neighbors,
         );
+
+        // Record the perplexity used so a later change invalidates the cache.
+        self.cached_perplexity = Some(self.perplexity);
 
         // Normalize P, seed the embedding, then run the optimization loop.
         self.barnes_hut_optimize(theta, grad_entries)
@@ -1091,14 +1097,19 @@ where
 
     /// Returns true if cached affinities match the current dataset.
     fn has_cached_affinities(&self, n_samples: usize) -> bool {
-        !self.p_rows.is_empty() && self.p_rows.len() == n_samples + 1
+        !self.p_rows.is_empty()
+            && self.p_rows.len() == n_samples + 1
+            && self.cached_perplexity == Some(self.perplexity)
     }
 
     /// Returns true if cached affinities encode the same neighbor indices as
     /// the provided neighbors slice. Returns false if affinities are absent
     /// or neighbors differ.
     fn cached_affinities_match_neighbors(&self, neighbors: &[Vec<Neighbor<T>>]) -> bool {
-        if self.p_rows.is_empty() || self.p_rows.len() != neighbors.len() + 1 {
+        if self.p_rows.is_empty()
+            || self.p_rows.len() != neighbors.len() + 1
+            || self.cached_perplexity != Some(self.perplexity)
+        {
             return false;
         }
         let p_rows = &self.p_rows;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1114,7 +1114,7 @@ where
         }
         let p_rows = &self.p_rows;
         let p_columns = &self.p_columns;
-        neighbors.par_iter().enumerate().all(|(i, row)| {
+        neighbors.iter().enumerate().all(|(i, row)| {
             let start = p_rows[i];
             let end = p_rows[i + 1];
             (end - start) == row.len()

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1130,6 +1130,7 @@ where
     where
         Dim<D>: Morton<D>,
     {
+        self.stop_lying_fired = false;
         let grad_entries = n_samples * D;
         self.y.resize(grad_entries, T::zero());
         self.uy.resize(grad_entries, T::zero());

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -734,8 +734,13 @@ where
             "error: every neighbors row must have the same length, greater than zero."
         );
 
-        // These indices later index P rows in symmetrize_sparse_matrix; reject
-        // out-of-range here instead of panicking cryptically there.
+        // If cached affinities encode the same neighbors, reuse them.
+        // Indices are provably valid from the run that produced the cache.
+        if self.cached_affinities_match_neighbors(neighbors) {
+            return self.run_cached_affinities(theta, n_samples);
+        }
+
+        // Cache miss: indices will be used, validate them.
         assert!(
             neighbors
                 .iter()
@@ -743,11 +748,6 @@ where
                 .all(|neighbor| neighbor.index < n_samples),
             "error: a neighbor index is out of range, every index must be < n_samples = {n_samples}."
         );
-
-        // If cached affinities encode the same neighbors, reuse them.
-        if self.cached_affinities_match_neighbors(neighbors) {
-            return self.run_cached_affinities(theta, n_samples);
-        }
 
         self.barnes_hut_fit(theta, n_neighbors, |index, p_columns_row, distances_row| {
             p_columns_row

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -107,6 +107,15 @@ pub struct Neighbor<T> {
     pub index: usize,
     pub distance: T,
 }
+/// A precomputed sparse, symmetric affinity graph in the CSR-like layout
+/// `barnes_hut` uses internally. Obtain via [`tSNE::affinities`] and inject
+/// with [`tSNE::with_affinities`].
+#[derive(Clone)]
+pub struct SparseAffinities<T> {
+    rows: Vec<usize>,
+    columns: Vec<u32>,
+    values: Vec<T>,
+}
 
 /// t-distributed stochastic neighbor embedding. Provides a parallel implementation of both the
 /// exact version of the algorithm and the tree accelerated one leveraging space partitioning trees.
@@ -135,6 +144,7 @@ where
     gains: Vec<T>,
     epoch_callback: Option<EpochCallback<'data, T>>,
     initial_embedding: Option<Vec<T>>,
+    stop_lying_fired: bool,
     fit: Option<Fit<T>>,
 }
 
@@ -222,6 +232,7 @@ where
             gains: Vec::new(),
             epoch_callback: None,
             initial_embedding: None,
+            stop_lying_fired: false,
             fit: None,
         }
     }
@@ -654,13 +665,17 @@ where
         F: Fn(&U, &U) -> T + Send + Sync,
         Dim<D>: Morton<D>,
     {
-        // Validate before building the tree so misuse does not pay for it first.
+        // Validate before doing any work.
         self.validate_fit_params(theta);
 
+        let n_samples = self.data.len();
+        if self.has_cached_affinities(n_samples) {
+            return self.run_cached_affinities(theta, n_samples);
+        }
+        // No cached affinities or mismatched dataset — rebuild.
         let data = self.data;
         // Number of points to consider when approximating the conditional distribution P.
         let n_neighbors: usize = (T::from(3.0).unwrap() * self.perplexity).as_();
-
         // Build ball tree on the data set.
         let tree = tsne::vptree::VPTree::new(data, &metric_f);
 
@@ -729,6 +744,11 @@ where
             "error: a neighbor index is out of range, every index must be < n_samples = {n_samples}."
         );
 
+        // If cached affinities encode the same neighbors, reuse them.
+        if self.cached_affinities_match_neighbors(neighbors) {
+            return self.run_cached_affinities(theta, n_samples);
+        }
+
         self.barnes_hut_fit(theta, n_neighbors, |index, p_columns_row, distances_row| {
             p_columns_row
                 .iter_mut()
@@ -741,7 +761,38 @@ where
         })
     }
 
-    /// Shared Barnes-Hut fit. `fill_neighbors(index, p_columns_row, distances_row)`
+    /// Returns the affinity graph from the last `barnes_hut` fit in pristine
+    /// (pre-exaggeration) form, or `None` if no Barnes-Hut fit has run.
+    /// Its values sum to approximately 1.
+    ///
+    pub fn affinities(&self) -> Option<SparseAffinities<T>> {
+        if self.p_rows.is_empty() {
+            return None;
+        }
+        // Undo exaggeration unless stop_lying has already undone it.
+        let values = if self.stop_lying_fired {
+            self.p_values.clone()
+        } else {
+            let scale = T::one() / self.early_exaggeration;
+            self.p_values.iter().map(|v| *v * scale).collect()
+        };
+        Some(SparseAffinities {
+            rows: self.p_rows.clone(),
+            columns: self.p_columns.clone(),
+            values,
+        })
+    }
+
+    /// Injects a previously extracted affinity graph. The next `barnes_hut`
+    /// call will reuse it and skip the neighbor search.
+    ///
+    /// [`barnes_hut`]: tSNE::barnes_hut
+    pub fn with_affinities(&mut self, affinities: SparseAffinities<T>) -> &mut Self {
+        self.p_rows = affinities.rows;
+        self.p_columns = affinities.columns;
+        self.p_values = affinities.values;
+        self
+    }
     /// writes sample `index`'s neighbor indices and distances; the rest is common.
     fn barnes_hut_fit<F>(&mut self, theta: T, n_neighbors: usize, fill_neighbors: F) -> &mut Self
     where
@@ -806,15 +857,35 @@ where
             &n_neighbors,
         );
 
+        // Normalize P, seed the embedding, then run the optimization loop.
+        self.barnes_hut_optimize(theta, grad_entries)
+    }
+
+    /// Runs the Barnes-Hut optimization loop. Normalizes P (applying
+    /// exaggeration), seeds the embedding, then runs the epoch loop.
+    fn barnes_hut_optimize(&mut self, theta: T, grad_entries: usize) -> &mut Self
+    where
+        Dim<D>: Morton<D>,
+    {
         // Normalize P, disable the early exaggeration if requested, and seed the embedding.
         self.finalize_p_and_seed(grad_entries);
 
+        self.barnes_hut_run_loop(theta, grad_entries)
+    }
+
+    /// Runs the Barnes-Hut epoch loop. Called after setup (normalization,
+    /// seeding) is complete. The caller must have `self.p_rows` /
+    /// `self.p_columns` / `self.p_values` populated.
+    fn barnes_hut_run_loop(&mut self, theta: T, grad_entries: usize) -> &mut Self
+    where
+        Dim<D>: Morton<D>,
+    {
         // Prepares buffers for Barnes-Hut algorithm.
         let mut positive_forces: Vec<T> = vec![T::zero(); grad_entries];
         let mut negative_forces: Vec<T> = vec![T::zero(); grad_entries];
 
         // Per-sample contribution to the Q normalization term, reduced after the force pass.
-        let mut q_sums: Vec<T> = vec![T::zero(); n_samples];
+        let mut q_sums: Vec<T> = vec![T::zero(); self.data.len()];
 
         // Per-dimension means for the zero-mean recentering, reused across epochs.
         let mut means: Vec<T> = vec![T::zero(); D];
@@ -823,6 +894,7 @@ where
         let (mut epoch_callback, mut snapshot) = self.take_callback_and_snapshot(grad_entries);
 
         // The theta acceptance test uses the squared form, so precompute theta squared once.
+        let n_samples = self.data.len();
         let theta_sq = theta * theta;
 
         // Main Training loop.
@@ -996,6 +1068,7 @@ where
     ) {
         if epoch == self.stop_lying_epoch && epoch != 0 {
             tsne::stop_lying(&mut self.p_values, self.early_exaggeration);
+            self.stop_lying_fired = true;
         }
         if epoch == self.momentum_switch_epoch {
             self.momentum = self.final_momentum;
@@ -1014,6 +1087,44 @@ where
             A value of 0.0 corresponds to using the exact version of the algorithm."
         );
         tsne::check_perplexity(&self.perplexity, &self.data.len());
+    }
+
+    /// Returns true if cached affinities match the current dataset.
+    fn has_cached_affinities(&self, n_samples: usize) -> bool {
+        !self.p_rows.is_empty() && self.p_rows.len() == n_samples + 1
+    }
+
+    /// Returns true if cached affinities encode the same neighbor indices as
+    /// the provided neighbors slice. Returns false if affinities are absent
+    /// or neighbors differ.
+    fn cached_affinities_match_neighbors(&self, neighbors: &[Vec<Neighbor<T>>]) -> bool {
+        if self.p_rows.is_empty() || self.p_rows.len() != neighbors.len() + 1 {
+            return false;
+        }
+        let p_rows = &self.p_rows;
+        let p_columns = &self.p_columns;
+        neighbors.par_iter().enumerate().all(|(i, row)| {
+            let start = p_rows[i];
+            let end = p_rows[i + 1];
+            (end - start) == row.len()
+                && row
+                    .iter()
+                    .enumerate()
+                    .all(|(j, neighbor)| p_columns[start + j] == neighbor.index as u32)
+        })
+    }
+
+    /// Runs the cached-affinities optimization path.
+    fn run_cached_affinities(&mut self, theta: T, n_samples: usize) -> &mut Self
+    where
+        Dim<D>: Morton<D>,
+    {
+        let grad_entries = n_samples * D;
+        self.y.resize(grad_entries, T::zero());
+        self.uy.resize(grad_entries, T::zero());
+        self.gains.resize(grad_entries, T::one());
+        self.finalize_p_and_seed(grad_entries);
+        self.barnes_hut_run_loop(theta, grad_entries)
     }
 
     /// Writes the embedding to a csv file. If the embedding space dimensionality is either equal to

--- a/src/test.rs
+++ b/src/test.rs
@@ -1683,3 +1683,21 @@ fn cached_affinities_reset_stop_lying_flag() {
         "second cached-affinities run produced different embedding: stop_lying_fired was not reset",
     );
 }
+
+#[test]
+#[should_panic(expected = "cached affinities were built with a different perplexity")]
+fn with_affinities_panics_on_perplexity_mismatch() {
+    let data: Vec<f32> = (0..800).map(|i| i as f32).collect();
+    let samples: Vec<&[f32]> = data.chunks(4).collect();
+
+    // Build affinities at perplexity 30.
+    let mut tsne: tSNE<f32, &[f32]> = tSNE::new(&samples);
+    tsne.perplexity(30.0).epochs(20);
+    tsne.barnes_hut(THETA, |a, b| euclidean(a, b));
+    let affinities = tsne.affinities().unwrap();
+
+    // Try to inject into an instance with a different perplexity.
+    let mut tsne2: tSNE<f32, &[f32]> = tSNE::new(&samples);
+    tsne2.perplexity(5.0);
+    tsne2.with_affinities(affinities);
+}

--- a/src/test.rs
+++ b/src/test.rs
@@ -1503,7 +1503,7 @@ fn cached_affinities_random_seed() {
     // Values should not all be zero (random init should produce variation).
     assert!(
         embedding.iter().any(|v| *v != 0.0),
-        "embedding is all zeros — random init may have failed",
+        "embedding is all zeros, random init may have failed",
     );
 }
 
@@ -1533,7 +1533,7 @@ fn cached_affinities_discarded_on_dataset_mismatch() {
         .perplexity(PERPLEXITY)
         .with_affinities(affinities);
 
-    // Should not panic — affinities are silently discarded and rebuilt.
+    // Should not panic, affinities are silently discarded and rebuilt.
     tsne_large.barnes_hut(THETA, |a, b| euclidean(a, b));
     let embedding = tsne_large.embedding();
 

--- a/src/test.rs
+++ b/src/test.rs
@@ -1543,3 +1543,75 @@ fn cached_affinities_discarded_on_dataset_mismatch() {
         "embedding contains non-finite values",
     );
 }
+/// Changing perplexity after a fit must invalidate the cached affinities:
+/// the second run recomputes P with the new perplexity rather than reusing
+/// stale values. Both paths run in a single-thread pool so the Barnes-Hut
+/// reductions are deterministic and the embeddings are bit-comparable.
+#[test]
+fn cached_affinities_invalidated_on_perplexity_change() {
+    const N: usize = 80;
+
+    let data = lcg_samples(N, D, 42);
+    let samples: Vec<&[f32]> = data.chunks(D).collect();
+
+    let new_perplexity = 2.0_f32;
+    let n_neighbors = (3.0 * new_perplexity) as usize;
+    let neighbors = brute_force_neighbors(&samples, n_neighbors);
+
+    // Seed from a preliminary run.
+    let mut tsne_seed: tSNE<f32, &[f32]> = tSNE::new(&samples);
+    tsne_seed.perplexity(PERPLEXITY).epochs(20);
+    tsne_seed.barnes_hut(THETA, |a, b| euclidean(a, b));
+    let seed = tsne_seed.embedding();
+
+    // Build reference affinities with new_perplexity.
+    let mut tsne_ref: tSNE<f32, &[f32]> = tSNE::new(&samples);
+    tsne_ref.perplexity(new_perplexity);
+    tsne_ref.barnes_hut_with_neighbors(THETA, &neighbors);
+    let affinities = tsne_ref.affinities().unwrap();
+
+    // Single-thread pool for deterministic Barnes-Hut reductions.
+    let pool = rayon::ThreadPoolBuilder::new()
+        .num_threads(1)
+        .build()
+        .unwrap();
+    let (result_a, result_b) = pool.install(|| {
+        // Path A: inject affinities, change perplexity, run.
+        // The cache should be invalidated because perplexity changed.
+        let mut tsne_a: tSNE<f32, &[f32]> = tSNE::new(&samples);
+        tsne_a
+            .perplexity(new_perplexity)
+            .with_affinities(affinities.clone())
+            .epochs(50)
+            .initial_embedding(seed.clone());
+        // Change perplexity AFTER caching.
+        tsne_a.perplexity(PERPLEXITY);
+        tsne_a.barnes_hut_with_neighbors(THETA, &neighbors);
+        let result_a = tsne_a.embedding();
+
+        // Path B: inject affinities, same perplexity, run.
+        // Cache should be reused.
+        let mut tsne_b: tSNE<f32, &[f32]> = tSNE::new(&samples);
+        tsne_b
+            .perplexity(new_perplexity)
+            .with_affinities(affinities)
+            .epochs(50)
+            .initial_embedding(seed);
+        tsne_b.barnes_hut_with_neighbors(THETA, &neighbors);
+        let result_b = tsne_b.embedding();
+
+        (result_a, result_b)
+    });
+
+    // Path A recomputes P (cache invalidated by perplexity change),
+    // Path B reuses cached P. Different P distributions produce
+    // different embeddings, so they must NOT match.
+    let any_diff = result_a
+        .iter()
+        .zip(result_b.iter())
+        .any(|(a, b)| (a - b).abs() > 1e-6);
+    assert!(
+        any_diff,
+        "embeddings are identical: perplexity change did not invalidate cache",
+    );
+}

--- a/src/test.rs
+++ b/src/test.rs
@@ -1615,3 +1615,71 @@ fn cached_affinities_invalidated_on_perplexity_change() {
         "embeddings are identical: perplexity change did not invalidate cache",
     );
 }
+/// Running barnes_hut twice on the same instance (second run hits the
+/// cached-affinities path) must produce the same result as running on a fresh
+/// instance with injected affinities. If `stop_lying_fired` is not reset before
+/// the second run, `stop_lying` never fires and the exaggeration is never
+/// removed, producing a different embedding.
+#[test]
+fn cached_affinities_reset_stop_lying_flag() {
+    const N: usize = 80;
+    const SL_EPOCH: usize = 5;
+    const RUN_EPOCHS: usize = 20;
+
+    let data = lcg_samples(N, D, 42);
+    let samples: Vec<&[f32]> = data.chunks(D).collect();
+
+    let n_neighbors = (3.0 * PERPLEXITY) as usize;
+    let neighbors = brute_force_neighbors(&samples, n_neighbors);
+
+    // Reference run to build affinities.
+    let mut tsne_ref: tSNE<f32, &[f32]> = tSNE::new(&samples);
+    tsne_ref.perplexity(PERPLEXITY);
+    tsne_ref.barnes_hut_with_neighbors(THETA, &neighbors);
+    let affinities = tsne_ref.affinities().unwrap();
+
+    // Seed from a preliminary run.
+    let mut tsne_seed: tSNE<f32, &[f32]> = tSNE::new(&samples);
+    tsne_seed.perplexity(PERPLEXITY).epochs(20);
+    tsne_seed.barnes_hut(THETA, |a, b| euclidean(a, b));
+    let seed = tsne_seed.embedding();
+
+    // Single-thread pool for deterministic reductions.
+    let pool = rayon::ThreadPoolBuilder::new()
+        .num_threads(1)
+        .build()
+        .unwrap();
+    let (result_a, result_b) = pool.install(|| {
+        // Path A: fresh instance with injected affinities.
+        // stop_lying_fired starts false; stop_lying fires at SL_EPOCH.
+        let mut tsne_a: tSNE<f32, &[f32]> = tSNE::new(&samples);
+        tsne_a
+            .perplexity(PERPLEXITY)
+            .with_affinities(affinities.clone())
+            .stop_lying_epoch(SL_EPOCH)
+            .epochs(RUN_EPOCHS)
+            .initial_embedding(seed.clone());
+        tsne_a.barnes_hut_with_neighbors(THETA, &neighbors);
+        let result_a = tsne_a.embedding();
+
+        // Path B: run twice on the same instance.
+        // First run sets stop_lying_fired = true.
+        // Second run should reset it; if not, stop_lying never fires.
+        let mut tsne_b: tSNE<f32, &[f32]> = tSNE::new(&samples);
+        tsne_b
+            .perplexity(PERPLEXITY)
+            .stop_lying_epoch(SL_EPOCH)
+            .epochs(RUN_EPOCHS);
+        tsne_b.barnes_hut_with_neighbors(THETA, &neighbors);
+        tsne_b.epochs(RUN_EPOCHS).initial_embedding(seed);
+        tsne_b.barnes_hut_with_neighbors(THETA, &neighbors);
+        let result_b = tsne_b.embedding();
+
+        (result_a, result_b)
+    });
+
+    assert_eq!(
+        result_a, result_b,
+        "second cached-affinities run produced different embedding: stop_lying_fired was not reset",
+    );
+}

--- a/src/test.rs
+++ b/src/test.rs
@@ -1,4 +1,5 @@
 use super::{Neighbor, tSNE, tsne};
+use rand::Rng;
 
 const D: usize = 4;
 const THETA: f32 = 0.5;
@@ -1213,5 +1214,332 @@ fn barnes_hut_does_not_collapse_embedding() {
         distinct.len() > N / 2,
         "embedding collapsed: only {} distinct positions for {N} points",
         distinct.len()
+    );
+}
+
+/// Round trip: run barnes_hut, extract affinities, inject them with initial_embedding
+/// into a second tSNE, and call barnes_hut again. The continuation stays closer
+/// to the seed than a random-init run, and cluster structure is preserved.
+#[test]
+fn affinities_round_trip_barnes_hut() {
+    const N: usize = 200;
+    let data = lcg_samples(N, D, 42);
+    let samples: Vec<&[f32]> = data.chunks(D).collect();
+
+    // First run.
+    let mut tsne1: tSNE<f32, &[f32]> = tSNE::new(&samples);
+    tsne1
+        .perplexity(PERPLEXITY)
+        .epochs(EPOCHS)
+        .barnes_hut(THETA, |a, b| euclidean(a, b));
+    let embedding1 = tsne1.embedding();
+    let affinities = tsne1.affinities().expect("should have affinities");
+
+    // Second run: warm start with affinities.
+    let mut tsne2: tSNE<f32, &[f32]> = tSNE::new(&samples);
+    tsne2
+        .perplexity(PERPLEXITY)
+        .epochs(500)
+        .initial_embedding(embedding1.clone())
+        .with_affinities(affinities);
+    tsne2.barnes_hut(THETA, |a, b| euclidean(a, b));
+    let embedding2 = tsne2.embedding();
+
+    // The continuation must start near the seed, not restart from random.
+    // Compare against a fresh random-init run: the warm-start embedding
+    // should be closer to the seed than a random run would be.
+    let mut tsne_rand: tSNE<f32, &[f32]> = tSNE::new(&samples);
+    tsne_rand
+        .perplexity(PERPLEXITY)
+        .epochs(500)
+        .barnes_hut(THETA, |a, b| euclidean(a, b));
+    let embedding_rand = tsne_rand.embedding();
+
+    let dist_warm = mean_point_distance(&embedding1, &embedding2, D);
+    let dist_rand = mean_point_distance(&embedding1, &embedding_rand, D);
+    assert!(
+        dist_warm < dist_rand,
+        "warm start ({}) should be closer to seed than random ({})",
+        dist_warm,
+        dist_rand,
+    );
+
+    // Cluster structure should be preserved: relative ordering of nearby points
+    // should be similar.
+    let data10 = &data[..D * 10];
+    let dist1 = mean_point_distance(data10, &embedding1[..D * 10], D);
+    let dist2 = mean_point_distance(data10, &embedding2[..D * 10], D);
+    assert!(
+        (dist1 - dist2).abs() < dist1 * 0.5,
+        "cluster structure changed too much: {} vs {}",
+        dist1,
+        dist2,
+    );
+}
+
+/// Equivalence: a second barnes_hut call reusing cached affinities produces
+/// the same embedding as a plain barnes_hut continuation within tolerance.
+#[test]
+fn affinities_equivalence_first_step() {
+    const N: usize = 100;
+    const CAPTURE: usize = 1; // Compare after 1 epoch.
+
+    let data = lcg_samples(N, D, 99);
+    let samples: Vec<&[f32]> = data.chunks(D).collect();
+
+    // Build affinities from a reference run.
+    let mut tsne_ref: tSNE<f32, &[f32]> = tSNE::new(&samples);
+    tsne_ref
+        .perplexity(PERPLEXITY)
+        .epochs(EPOCHS)
+        .barnes_hut(THETA, |a, b| euclidean(a, b));
+    let affinities = tsne_ref.affinities().unwrap();
+    let seed = tsne_ref.embedding();
+
+    // Path A: plain barnes_hut continuation from the seed.
+    let mut tsne_a: tSNE<f32, &[f32]> = tSNE::new(&samples);
+    tsne_a
+        .perplexity(PERPLEXITY)
+        .epochs(CAPTURE + 1)
+        .initial_embedding(seed.clone());
+    tsne_a.barnes_hut(THETA, |a, b| euclidean(a, b));
+    let result_a = tsne_a.embedding();
+
+    // Path B: barnes_hut with cached affinities from the same seed.
+    let mut tsne_b: tSNE<f32, &[f32]> = tSNE::new(&samples);
+    tsne_b
+        .perplexity(PERPLEXITY)
+        .epochs(CAPTURE + 1)
+        .initial_embedding(seed)
+        .with_affinities(affinities);
+    tsne_b.barnes_hut(THETA, |a, b| euclidean(a, b));
+    let result_b = tsne_b.embedding();
+
+    // Two runs on the same thread pool may differ by parallel-reduction noise,
+    // so use a tolerance.
+    let max_diff: f32 = result_a
+        .iter()
+        .zip(result_b.iter())
+        .map(|(a, b)| (a - b).abs())
+        .max_by(|a, b| a.partial_cmp(b).unwrap())
+        .unwrap();
+    let scale = result_a
+        .iter()
+        .map(|v| v.abs())
+        .max_by(|a, b| a.partial_cmp(b).unwrap())
+        .unwrap();
+    assert!(
+        max_diff / scale < 1e-3,
+        "precomputed path diverged from reference: max_diff={max_diff}, scale={scale}",
+    );
+}
+
+/// affinities() returns values summing to about 1 regardless of run length.
+#[test]
+fn affinities_pristine_independent_of_run_length() {
+    const N: usize = 100;
+
+    let data = lcg_samples(N, D, 7);
+    let samples: Vec<&[f32]> = data.chunks(D).collect();
+
+    // Short run: fewer epochs than stop_lying_epoch (250).
+    let mut tsne_short: tSNE<f32, &[f32]> = tSNE::new(&samples);
+    tsne_short
+        .perplexity(PERPLEXITY)
+        .epochs(50)
+        .barnes_hut(THETA, |a, b| euclidean(a, b));
+    let affinities_short = tsne_short.affinities().unwrap();
+    let sum_short: f32 = affinities_short.values.iter().sum();
+
+    // Long run: more epochs than stop_lying_epoch.
+    let mut tsne_long: tSNE<f32, &[f32]> = tSNE::new(&samples);
+    tsne_long
+        .perplexity(PERPLEXITY)
+        .epochs(1000)
+        .barnes_hut(THETA, |a, b| euclidean(a, b));
+    let affinities_long = tsne_long.affinities().unwrap();
+    let sum_long: f32 = affinities_long.values.iter().sum();
+
+    // Both should sum to approximately 1 (pristine P).
+    assert!(
+        (sum_short - 1.0).abs() < 0.05,
+        "short run affinities sum to {sum_short}, expected ~1",
+    );
+    assert!(
+        (sum_long - 1.0).abs() < 0.05,
+        "long run affinities sum to {sum_long}, expected ~1",
+    );
+    // And they should be identical since the data and perplexity are the same.
+    assert_eq!(
+        affinities_short.rows, affinities_long.rows,
+        "row structure differs between short and long runs",
+    );
+    assert_eq!(
+        affinities_short.columns, affinities_long.columns,
+        "column structure differs between short and long runs",
+    );
+    for (a, b) in affinities_short
+        .values
+        .iter()
+        .zip(affinities_long.values.iter())
+    {
+        assert!((a - b).abs() < 1e-6, "value differs: {} vs {}", a, b,);
+    }
+}
+
+/// Cached affinities are reused in barnes_hut_with_neighbors when custom
+/// neighbors match the cached neighbor indices. When they differ, the
+/// custom neighbors are used and affinities are regenerated.
+#[test]
+fn affinities_work_with_custom_neighbors() {
+    const N: usize = 100;
+
+    let data = lcg_samples(N, D, 42);
+    let samples: Vec<&[f32]> = data.chunks(D).collect();
+
+    // Build affinities from a reference run.
+    let mut tsne_ref: tSNE<f32, &[f32]> = tSNE::new(&samples);
+    tsne_ref
+        .perplexity(PERPLEXITY)
+        .epochs(EPOCHS)
+        .barnes_hut(THETA, |a, b| euclidean(a, b));
+    let affinities = tsne_ref.affinities().unwrap();
+    let seed = tsne_ref.embedding();
+
+    // Build different custom neighbors.
+    let mut rng = rand::rng();
+    let different_neighbors: Vec<Vec<Neighbor<f32>>> = samples
+        .iter()
+        .enumerate()
+        .map(|(sample_idx, _)| {
+            let mut row: Vec<Neighbor<f32>> = (0..N)
+                .filter_map(|i| {
+                    if i == sample_idx {
+                        None
+                    } else {
+                        Some(Neighbor {
+                            index: i,
+                            distance: rng.random_range(0.0..100.0),
+                        })
+                    }
+                })
+                .collect();
+            row.truncate(15);
+            row
+        })
+        .collect();
+
+    // Path B: cached affinities + different custom neighbors.
+    let mut tsne_b: tSNE<f32, &[f32]> = tSNE::new(&samples);
+    tsne_b
+        .perplexity(PERPLEXITY)
+        .epochs(50)
+        .initial_embedding(seed.clone())
+        .with_affinities(affinities.clone());
+    tsne_b.barnes_hut_with_neighbors(THETA, &different_neighbors);
+    let result_b = tsne_b.embedding();
+
+    // Path C: cached affinities + barnes_hut (no custom neighbors).
+    let mut tsne_c: tSNE<f32, &[f32]> = tSNE::new(&samples);
+    tsne_c
+        .perplexity(PERPLEXITY)
+        .epochs(50)
+        .initial_embedding(seed)
+        .with_affinities(affinities);
+    tsne_c.barnes_hut(THETA, |a, b| euclidean(a, b));
+    let result_c = tsne_c.embedding();
+
+    // When neighbors differ, Path B uses custom neighbors and diverges
+    // from the cached path (Path C).
+    let max_diff: f32 = result_b
+        .iter()
+        .zip(result_c.iter())
+        .map(|(a, b)| (a - b).abs())
+        .max_by(|a, b| a.partial_cmp(b).unwrap())
+        .unwrap();
+    let scale = result_b
+        .iter()
+        .map(|v| v.abs())
+        .max_by(|a, b| a.partial_cmp(b).unwrap())
+        .unwrap();
+    assert!(
+        max_diff / scale > 0.05,
+        "different neighbors should invalidate cached affinities: max_diff={}, scale={}",
+        max_diff,
+        scale,
+    );
+}
+
+/// Cached affinities path works with random seed when no initial_embedding is set.
+#[test]
+fn cached_affinities_random_seed() {
+    const N: usize = 50;
+
+    let data = lcg_samples(N, D, 7);
+    let samples: Vec<&[f32]> = data.chunks(D).collect();
+
+    // Build affinities from a reference run.
+    let mut tsne_ref: tSNE<f32, &[f32]> = tSNE::new(&samples);
+    tsne_ref
+        .perplexity(PERPLEXITY)
+        .epochs(EPOCHS)
+        .barnes_hut(THETA, |a, b| euclidean(a, b));
+    let affinities = tsne_ref.affinities().unwrap();
+
+    // Cached path with random seed (no initial_embedding).
+    let mut tsne: tSNE<f32, &[f32]> = tSNE::new(&samples);
+    tsne.perplexity(PERPLEXITY)
+        .epochs(50)
+        .with_affinities(affinities);
+    tsne.barnes_hut(THETA, |a, b| euclidean(a, b));
+    let embedding = tsne.embedding();
+
+    // Basic sanity: embedding has correct shape and finite values.
+    assert_eq!(embedding.len(), N * 2);
+    assert!(
+        embedding.iter().all(|v| v.is_finite()),
+        "embedding contains non-finite values",
+    );
+    // Values should not all be zero (random init should produce variation).
+    assert!(
+        embedding.iter().any(|v| *v != 0.0),
+        "embedding is all zeros — random init may have failed",
+    );
+}
+
+/// Mismatched dataset size causes cached affinities to be discarded and
+/// rebuilt via the VPTree path.
+#[test]
+fn cached_affinities_discarded_on_dataset_mismatch() {
+    const N_SMALL: usize = 50;
+    const N_LARGE: usize = 100;
+
+    let data_small = lcg_samples(N_SMALL, D, 7);
+    let samples_small: Vec<&[f32]> = data_small.chunks(D).collect();
+
+    // Build affinities from a small dataset.
+    let mut tsne_small: tSNE<f32, &[f32]> = tSNE::new(&samples_small);
+    tsne_small
+        .perplexity(PERPLEXITY)
+        .epochs(EPOCHS)
+        .barnes_hut(THETA, |a, b| euclidean(a, b));
+    let affinities = tsne_small.affinities().unwrap();
+
+    // Inject affinities from a different-sized dataset.
+    let data_large = lcg_samples(N_LARGE, D, 7);
+    let samples_large: Vec<&[f32]> = data_large.chunks(D).collect();
+    let mut tsne_large: tSNE<f32, &[f32]> = tSNE::new(&samples_large);
+    tsne_large
+        .perplexity(PERPLEXITY)
+        .with_affinities(affinities);
+
+    // Should not panic — affinities are silently discarded and rebuilt.
+    tsne_large.barnes_hut(THETA, |a, b| euclidean(a, b));
+    let embedding = tsne_large.embedding();
+
+    assert_eq!(embedding.len(), N_LARGE * 2);
+    assert!(
+        embedding.iter().all(|v| v.is_finite()),
+        "embedding contains non-finite values",
     );
 }


### PR DESCRIPTION
Extract the cached-affinities check into shared helpers so both barnes_hut and barnes_hut_with_neighbors skip the neighbor search when affinities from a previous fit are already cached.

Cached affinities are reused only when the custom neighbors match the cached neighbor indices. When they differ, the custom neighbors are used and affinities are regenerated.

Basically I will use this to speedup tuning the parameters of the iterative part after affinities.