### PR TITLE
Implement arena-based `VPTreee` and re-use `Arena` buffers

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -547,7 +547,7 @@ where
             self.q_values
                 .par_iter_mut()
                 .zip(distances.par_iter())
-                .for_each(|(q, d)| *q = T::one() / (T::one() + *d));
+                .for_each(|(q, d)| *q = (T::one() + *d).recip());
 
             // Computes the exact gradient in parallel.
             let q_values_sum: T = self.q_values.par_iter().copied().sum::<T>();
@@ -776,7 +776,7 @@ where
         let values = if self.stop_lying_fired {
             self.p_values.clone()
         } else {
-            let scale = T::one() / self.early_exaggeration;
+            let scale = self.early_exaggeration.recip();
             self.p_values.iter().map(|v| *v * scale).collect()
         };
         Some(SparseAffinities {
@@ -906,10 +906,14 @@ where
         let n_samples = self.data.len();
         let theta_sq = theta * theta;
 
+        // One arena, rebuilt in place each epoch so it reuses its buffers instead of
+        // reallocating every epoch.
+        let mut arena = tsne::arena::Arena::<T, D>::empty();
+
         // Main Training loop.
         for epoch in 0..self.epochs {
-            // Construct the Morton arena over the current embedding.
-            let arena = tsne::arena::Arena::<T, D>::new(&self.y, n_samples);
+            // Rebuild the Morton arena over the current embedding.
+            arena.rebuild(&self.y, n_samples);
             debug_assert!(
                 arena.centers_of_mass_within_cells(),
                 "error: arena centre of mass escaped its cell."
@@ -965,7 +969,7 @@ where
             // Sequential q_sum: barrier-free and negligible against the forces. The reciprocal is
             // precomputed so the fused update multiplies instead of dividing per value.
             let q_sum: T = q_sums.iter().copied().sum();
-            let inverse_q_sum = T::one() / q_sum;
+            let inverse_q_sum = q_sum.recip();
 
             // Fuse the gradient (`positive - negative * inverse_q_sum`) into the gradient-descent
             // update, so it needs no separate buffer or sweep.

--- a/src/tsne/arena.rs
+++ b/src/tsne/arena.rs
@@ -48,6 +48,11 @@ struct Node<T, const D: usize> {
 /// A Morton linear quadtree (`D == 2`) or octree (`D == 3`) over the embedding, in one arena.
 pub(crate) struct Arena<T, const D: usize> {
     nodes: Vec<Node<T, D>>,
+    /// Build scratch: each emitted node's half-open window in `sorted`. Retained with `nodes` so a
+    /// rebuild reuses the allocation rather than reallocating it every epoch.
+    ranges: Vec<(u32, u32)>,
+    /// The `(Morton code, point index)` permutation, retained across rebuilds to reuse its allocation.
+    sorted: Vec<(u64, u32)>,
     /// Squared maximum half-width of a cell at each level, indexed by `Node::level`. The theta
     /// acceptance test compares this against `theta^2 * dist`, the squared form of the reference
     /// `max_half_width / sqrt(dist) < theta`, avoiding a square root per visit.
@@ -91,7 +96,21 @@ impl<T, const D: usize> Arena<T, D>
 where
     T: Float + Send + Sync + AddAssign,
 {
-    /// Builds the arena over `y`, a flat buffer of `n_samples` points of `D` components each.
+    /// Creates an empty arena. The epoch loop holds one of these and rebuilds it each epoch so the
+    /// buffers persist and are reused.
+    pub(crate) fn empty() -> Self {
+        Self {
+            nodes: Vec::new(),
+            ranges: Vec::new(),
+            sorted: Vec::new(),
+            level_half_width_sq: Vec::new(),
+            coms_within_cells: true,
+        }
+    }
+
+    /// Builds a fresh arena over `y`, a flat buffer of `n_samples` points of `D` components each.
+    /// Convenience for one-shot callers and tests; the epoch loop instead holds one arena and calls
+    /// [`Arena::rebuild`] so the buffers persist and are reused.
     ///
     /// # Panics
     ///
@@ -101,14 +120,32 @@ where
     where
         Dim<D>: Morton<D>,
     {
+        let mut arena = Self::empty();
+        arena.rebuild(y, n_samples);
+        arena
+    }
+
+    /// Rebuilds the arena over `y`, a flat buffer of `n_samples` points of `D` components each, in
+    /// place, reusing the retained buffers rather than reallocating them each epoch.
+    ///
+    /// # Panics
+    ///
+    /// If the leaf masses do not sum to `n_samples` (point conservation), which a correct Morton
+    /// build always satisfies.
+    pub(crate) fn rebuild(&mut self, y: &[T], n_samples: usize)
+    where
+        Dim<D>: Morton<D>,
+    {
         let bits = <Dim<D> as Morton<D>>::BITS;
 
+        self.nodes.clear();
+        self.ranges.clear();
+        self.sorted.clear();
+        self.coms_within_cells = true;
+
         if n_samples == 0 {
-            return Self {
-                nodes: Vec::new(),
-                level_half_width_sq: Vec::new(),
-                coms_within_cells: true,
-            };
+            self.level_half_width_sq.clear();
+            return;
         }
 
         // 1. Bounding box and the derived quantization scale.
@@ -131,165 +168,169 @@ where
         // The squared half-width per level for the theta test: cell full width per axis at level L
         // is extent / 2^L, so the maximum half-width is max(extent) / 2^(L+1).
         let max_extent = extent.iter().copied().fold(T::zero(), T::max);
-        let mut level_half_width_sq = Vec::with_capacity(bits as usize + 1);
+        self.level_half_width_sq.clear();
         for level in 0..=bits {
             let half_width = max_extent / T::from(1u64 << (level + 1)).unwrap();
-            level_half_width_sq.push(half_width * half_width);
+            self.level_half_width_sq.push(half_width * half_width);
         }
 
-        // 2-4. Quantize, encode, and sort a (code, index) permutation into Z-order.
-        let mut sorted: Vec<(u64, u32)> = (0..n_samples)
-            .into_par_iter()
-            .with_min_len(PARALLEL_CODE_THRESHOLD)
-            .map(|i| {
-                let point = &y[i * D..i * D + D];
-                let code = <Dim<D> as Morton<D>>::encode(quantize::<T, D>(
-                    point, &min, &inv_scale, max_bucket,
-                ));
-                (code, i as u32)
-            })
-            .collect();
-        sorted.par_sort_unstable_by_key(|&(code, _)| code);
+        // 2-4. Quantize, encode, and sort a (code, index) permutation into Z-order. `sorted` is
+        // refilled from the cleared buffer, reusing its capacity across epochs.
+        self.sorted.par_extend(
+            (0..n_samples)
+                .into_par_iter()
+                .with_min_len(PARALLEL_CODE_THRESHOLD)
+                .map(|i| {
+                    let point = &y[i * D..i * D + D];
+                    let code = <Dim<D> as Morton<D>>::encode(quantize::<T, D>(
+                        point, &min, &inv_scale, max_bucket,
+                    ));
+                    (code, i as u32)
+                }),
+        );
+        self.sorted.par_sort_unstable_by_key(|&(code, _)| code);
 
-        // 5. Breadth-first emission: each node's children (the non-empty orthant groups at the
-        // node's tightest enclosing level) occupy a contiguous arena range. `ranges` carries each
-        // node's window in `sorted` and is build scratch only. Every internal node has at least two
-        // children (single-child chains are skipped by the tightest-enclosing-level jump), so an
-        // arena over `n` points holds at most `2n - 1` nodes; reserving that up front lets the
-        // sequential emission push without reallocating as it grows, every epoch.
-        let mut nodes: Vec<Node<T, D>> = Vec::with_capacity(2 * n_samples - 1);
-        let mut ranges: Vec<(u32, u32)> = Vec::with_capacity(2 * n_samples - 1);
-        nodes.push(Node {
-            center_of_mass: [T::zero(); D],
-            count: n_samples as u32,
-            first_child: SENTINEL,
-            child_count: 0,
-            level: bits as u8,
-        });
-        ranges.push((0, n_samples as u32));
+        let coms_within_cells = {
+            let sorted = &self.sorted;
+            let nodes = &mut self.nodes;
+            let ranges = &mut self.ranges;
 
-        let mask = (1u64 << D) - 1;
-        let mut node = 0usize;
-        while node < nodes.len() {
-            let (start, end) = ranges[node];
-            // A single point, or a cell of points that share a full code (closer than one grid
-            // cell, the duplicate case), is a leaf. Sorted codes make the all-equal test O(1).
-            if end - start <= 1 || sorted[start as usize].0 == sorted[(end - 1) as usize].0 {
-                node += 1;
-                continue;
-            }
+            // 5. Breadth-first emission: each node's children (the non-empty orthant groups at the
+            // node's tightest enclosing level) occupy a contiguous arena range. `ranges` carries each
+            // node's window in `sorted`. Every internal node has at least two children (single-child
+            // chains are skipped by the tightest-enclosing-level jump), so an arena over `n` points
+            // holds at most `2n - 1` nodes; reserving that up front lets the sequential emission push
+            // without reallocating (a no-op once the buffers have grown on the first epoch).
+            nodes.reserve(2 * n_samples - 1);
+            ranges.reserve(2 * n_samples - 1);
+            nodes.push(Node {
+                center_of_mass: [T::zero(); D],
+                count: n_samples as u32,
+                first_child: SENTINEL,
+                child_count: 0,
+                level: bits as u8,
+            });
+            ranges.push((0, n_samples as u32));
 
-            // Tightest enclosing level: the highest bit at which the range's extreme codes differ
-            // sits in the D-bit group that first splits the range, so the node skips straight to
-            // that level rather than emitting single-child chains.
-            let xor = sorted[start as usize].0 ^ sorted[(end - 1) as usize].0;
-            let highest_diff = 63 - xor.leading_zeros();
-            let level = (bits - 1) - highest_diff / D as u32;
-            let shift = D as u32 * (bits - 1 - level);
-            nodes[node].level = level as u8;
-
-            let first_child = nodes.len() as u32;
-            let mut child_count: u8 = 0;
-            let mut child_start = start;
-            while child_start < end {
-                let group = (sorted[child_start as usize].0 >> shift) & mask;
-                let mut child_end = child_start + 1;
-                while child_end < end && (sorted[child_end as usize].0 >> shift) & mask == group {
-                    child_end += 1;
+            let mask = (1u64 << D) - 1;
+            let mut node = 0usize;
+            while node < nodes.len() {
+                let (start, end) = ranges[node];
+                // A single point, or a cell of points that share a full code (closer than one grid
+                // cell, the duplicate case), is a leaf. Sorted codes make the all-equal test O(1).
+                if end - start <= 1 || sorted[start as usize].0 == sorted[(end - 1) as usize].0 {
+                    node += 1;
+                    continue;
                 }
-                nodes.push(Node {
-                    center_of_mass: [T::zero(); D],
-                    count: (child_end - child_start),
-                    first_child: SENTINEL,
-                    child_count: 0,
-                    level: bits as u8,
-                });
-                ranges.push((child_start, child_end));
-                child_count += 1;
-                child_start = child_end;
-            }
-            // A D-bit group has at most 2^D distinct values, so a cell never exceeds its orthants.
-            debug_assert!(child_count as usize <= <Dim<D> as Morton<D>>::CHILDREN);
-            nodes[node].first_child = first_child;
-            nodes[node].child_count = child_count;
-            node += 1;
-        }
 
-        // 6a. Leaf centers of mass: the mean of the leaf's member points, computed in parallel per
-        // leaf. Internal centers come from the bottom-up reduction below. `count` is already set
-        // (the range length) for every node, so only the centers remain.
-        nodes
-            .par_iter_mut()
-            .zip(ranges.par_iter())
-            .with_min_len(PARALLEL_CODE_THRESHOLD)
-            .for_each(|(node, &(start, end))| {
-                if node.first_child == SENTINEL {
-                    let mut center = [T::zero(); D];
-                    for slot in start..end {
-                        let index = sorted[slot as usize].1 as usize;
-                        let point = &y[index * D..index * D + D];
-                        for axis in 0..D {
-                            center[axis] += point[axis];
-                        }
+                // Tightest enclosing level: the highest bit at which the range's extreme codes differ
+                // sits in the D-bit group that first splits the range, so the node skips straight to
+                // that level rather than emitting single-child chains.
+                let xor = sorted[start as usize].0 ^ sorted[(end - 1) as usize].0;
+                let highest_diff = 63 - xor.leading_zeros();
+                let level = (bits - 1) - highest_diff / D as u32;
+                let shift = D as u32 * (bits - 1 - level);
+                nodes[node].level = level as u8;
+
+                let first_child = nodes.len() as u32;
+                let mut child_count: u8 = 0;
+                let mut child_start = start;
+                while child_start < end {
+                    let group = (sorted[child_start as usize].0 >> shift) & mask;
+                    let mut child_end = child_start + 1;
+                    while child_end < end && (sorted[child_end as usize].0 >> shift) & mask == group
+                    {
+                        child_end += 1;
                     }
-                    let inverse = T::one() / T::from(node.count).unwrap();
+                    nodes.push(Node {
+                        center_of_mass: [T::zero(); D],
+                        count: (child_end - child_start),
+                        first_child: SENTINEL,
+                        child_count: 0,
+                        level: bits as u8,
+                    });
+                    ranges.push((child_start, child_end));
+                    child_count += 1;
+                    child_start = child_end;
+                }
+                // A D-bit group has at most 2^D distinct values, so a cell never exceeds its orthants.
+                debug_assert!(child_count as usize <= <Dim<D> as Morton<D>>::CHILDREN);
+                nodes[node].first_child = first_child;
+                nodes[node].child_count = child_count;
+                node += 1;
+            }
+
+            // 6a. Leaf centers of mass: the mean of the leaf's member points, computed in parallel
+            // per leaf. Internal centers come from the bottom-up reduction below. `count` is already
+            // set (the range length) for every node, so only the centers remain.
+            nodes
+                .par_iter_mut()
+                .zip(ranges.par_iter())
+                .with_min_len(PARALLEL_CODE_THRESHOLD)
+                .for_each(|(node, &(start, end))| {
+                    if node.first_child == SENTINEL {
+                        let mut center = [T::zero(); D];
+                        for slot in start..end {
+                            let index = sorted[slot as usize].1 as usize;
+                            let point = &y[index * D..index * D + D];
+                            for axis in 0..D {
+                                center[axis] += point[axis];
+                            }
+                        }
+                        let inverse = T::from(node.count).unwrap().recip();
+                        center
+                            .iter_mut()
+                            .for_each(|value| *value = *value * inverse);
+                        node.center_of_mass = center;
+                    }
+                });
+
+            // 6b. Internal centers of mass, bottom up. Children always have a higher arena index than
+            // their parent (breadth-first emission), so a reverse pass sees every child finished, a
+            // count-weighted hierarchical average.
+            for node in (0..nodes.len()).rev() {
+                if nodes[node].first_child == SENTINEL {
+                    continue;
+                }
+                let first_child = nodes[node].first_child as usize;
+                let child_count = nodes[node].child_count as usize;
+                let total = T::from(nodes[node].count).unwrap();
+                let mut center = [T::zero(); D];
+                for child in &nodes[first_child..first_child + child_count] {
+                    let weight = T::from(child.count).unwrap();
                     center
                         .iter_mut()
-                        .for_each(|value| *value = *value * inverse);
-                    node.center_of_mass = center;
+                        .zip(child.center_of_mass.iter())
+                        .for_each(|(value, &component)| *value += component * weight);
                 }
-            });
-
-        // 6b. Internal centers of mass, bottom up. Children always have a higher arena index than
-        // their parent (breadth-first emission), so a reverse pass sees every child finished, a
-        // count-weighted hierarchical average.
-        for node in (0..nodes.len()).rev() {
-            if nodes[node].first_child == SENTINEL {
-                continue;
-            }
-            let first_child = nodes[node].first_child as usize;
-            let child_count = nodes[node].child_count as usize;
-            let total = T::from(nodes[node].count).unwrap();
-            let mut center = [T::zero(); D];
-            for child in &nodes[first_child..first_child + child_count] {
-                let weight = T::from(child.count).unwrap();
+                let inverse = total.recip();
                 center
                     .iter_mut()
-                    .zip(child.center_of_mass.iter())
-                    .for_each(|(value, &component)| *value += component * weight);
+                    .for_each(|value| *value = *value * inverse);
+                nodes[node].center_of_mass = center;
             }
-            let inverse = T::one() / total;
-            center
-                .iter_mut()
-                .for_each(|value| *value = *value * inverse);
-            nodes[node].center_of_mass = center;
-        }
 
-        // Point conservation: every input point lands in exactly one leaf, so the leaf masses must
-        // sum to the input count. Morton quantization guarantees this, but the check guards the
-        // breadth-first range bookkeeping. Kept as a release assert because correctness is not
-        // relaxed.
-        let leaf_mass: u64 = nodes
-            .iter()
-            .filter(|node| node.first_child == SENTINEL)
-            .map(|node| node.count as u64)
-            .sum();
-        assert_eq!(
-            leaf_mass as usize, n_samples,
-            "arena lost or invented points: {leaf_mass} in leaves != {n_samples}"
-        );
+            // Point conservation: every input point lands in exactly one leaf, so the leaf masses
+            // must sum to the input count. Morton quantization guarantees this, but the check guards
+            // the breadth-first range bookkeeping. Kept as a release assert because correctness is
+            // not relaxed.
+            let leaf_mass: u64 = nodes
+                .iter()
+                .filter(|node| node.first_child == SENTINEL)
+                .map(|node| node.count as u64)
+                .sum();
+            assert_eq!(
+                leaf_mass as usize, n_samples,
+                "arena lost or invented points: {leaf_mass} in leaves != {n_samples}"
+            );
 
-        let coms_within_cells = if cfg!(debug_assertions) {
-            check_coms_within_cells::<T, D>(&nodes, &ranges, &sorted, &min, &extent, bits)
-        } else {
-            true
+            if cfg!(debug_assertions) {
+                check_coms_within_cells::<T, D>(nodes, ranges, sorted, &min, &extent, bits)
+            } else {
+                true
+            }
         };
-
-        Self {
-            nodes,
-            level_half_width_sq,
-            coms_within_cells,
-        }
+        self.coms_within_cells = coms_within_cells;
     }
 
     /// Number of points the arena holds, the root mass. Used by the build-invariant tests, where
@@ -361,7 +402,7 @@ where
             }
 
             // Summarize the cell by its center of mass.
-            let inverse = T::one() / (T::one() + distance);
+            let inverse = (T::one() + distance).recip();
             let mut magnitude = T::from(node.count).unwrap() * inverse;
             *q_sum += magnitude;
             magnitude = magnitude * inverse;

--- a/src/tsne/mod.rs
+++ b/src/tsne/mod.rs
@@ -426,7 +426,7 @@ pub(super) fn stop_lying<T: Float + Send + Sync + MulAssign>(
     p_values: &mut [T],
     early_exaggeration: T,
 ) {
-    let scale = T::one() / early_exaggeration;
+    let scale = early_exaggeration.recip();
     p_values.par_iter_mut().for_each(|p| *p *= scale);
 }
 
@@ -498,10 +498,10 @@ where
     q_values
         .par_iter_mut()
         .zip(distances.par_iter())
-        .for_each(|(q, d)| *q = T::one() / (T::one() + *d));
+        .for_each(|(q, d)| *q = (T::one() + *d).recip());
 
     let q_sum = q_values.par_iter().map(|q| *q).sum::<T>();
-    let inverse_q_sum = T::one() / q_sum;
+    let inverse_q_sum = q_sum.recip();
     q_values
         .par_iter_mut()
         .for_each(|q| *q = *q * inverse_q_sum);
@@ -568,7 +568,7 @@ where
 
         q_sums.par_iter().map(|sum| *sum).sum::<T>()
     };
-    let inverse_q_sum = T::one() / q_sum;
+    let inverse_q_sum = q_sum.recip();
 
     let mut partials: Vec<T> = vec![T::zero(); n_samples];
 
@@ -586,7 +586,7 @@ where
                     .zip(sample_b.iter())
                     .map(|(a, b)| (*a - *b).powi(2))
                     .sum::<T>();
-                q = (T::one() / (T::one() + q)) * inverse_q_sum;
+                q = (T::one() + q).recip() * inverse_q_sum;
 
                 // Kullback-Leibler divergence.
                 *cost += p_values[index]

--- a/src/tsne/vptree.rs
+++ b/src/tsne/vptree.rs
@@ -4,22 +4,33 @@ use rand::Rng;
 
 use num_traits::Float;
 
-/// A node of the vantage point tree.
+/// `left`/`right` value marking the absence of a child.
+const SENTINEL: u32 = u32::MAX;
+
+/// One node of the flat vantage point tree. Node `0` is the root.
 #[derive(Clone, Debug)]
-pub(crate) struct Node<T: Float> {
-    index: usize,
+struct Node<T: Float> {
+    item: u32,
     threshold: T,
-    left: Option<Box<Node<T>>>,
-    right: Option<Box<Node<T>>>,
+    left: u32,
+    right: u32,
+}
+
+/// Which side of its parent a frame's node hangs off, so the build can wire the link once the
+/// node's arena index is known.
+enum Side {
+    Root,
+    Left,
+    Right,
 }
 
 impl<T: Float> Default for Node<T> {
     fn default() -> Self {
         Node {
-            index: 0,
+            item: 0,
             threshold: T::zero(),
-            left: None,
-            right: None,
+            left: SENTINEL,
+            right: SENTINEL,
         }
     }
 }
@@ -53,32 +64,10 @@ impl<T: Float> Ord for HeapItem<T> {
     }
 }
 
-/// Auxiliary struct used to build the vantage point tree.
-struct VPTreeBuilder<'a, T: Float> {
-    root: &'a mut Option<Box<Node<T>>>,
-    lower: usize,
-    upper: usize,
-}
-
-impl<'a, T: Float> VPTreeBuilder<'a, T> {
-    /// VPTreeBuilder constructor.
-    ///
-    /// # Arguments
-    ///
-    /// * `node` - current node.
-    ///
-    /// * `lower` - lower bound.
-    ///
-    /// * `upper` - upper bound.
-    fn new(root: &'a mut Option<Box<Node<T>>>, lower: usize, upper: usize) -> Self {
-        Self { root, lower, upper }
-    }
-}
-
 /// Vantage Point tree.
 pub(crate) struct VPTree<'a, T: Float + Send + Sync, U> {
     items: Vec<(usize, &'a U)>,
-    pub(crate) root: Option<Box<Node<T>>>,
+    nodes: Vec<Node<T>>,
 }
 
 impl<'a, T: Float + Send + Sync, U> VPTree<'a, T, U> {
@@ -97,72 +86,90 @@ impl<'a, T: Float + Send + Sync, U> VPTree<'a, T, U> {
             // Need to swap some references around, don't want to move original data.
             // Also need to keep track of the original position, as it will differ.
             items: items.iter().enumerate().collect(),
-            root: None,
+            nodes: Vec::new(),
         };
-        let n_samples = tree.items.len(); // Immutable borrow must be kept outside.
-        tree.build_from_points(0, n_samples, &metric_f);
+        tree.build(&metric_f);
 
         tree
     }
 
-    /// Function that iteratively fills the tree.
+    /// Builds the flat tree over `items`. Iterative, with an explicit frame stack standing in for
+    /// recursion: each frame is a half-open `items` range and the parent slot its node fills.
     ///
     /// # Arguments
     ///
-    /// * `lower' - lower bound.
-    ///
-    /// * `upper` - upper bound.
-    ///
     /// * `metric_f` - metric function.
-    fn build_from_points<F>(&mut self, lower: usize, upper: usize, metric_f: F)
+    fn build<F>(&mut self, metric_f: F)
     where
         F: Fn(&U, &U) -> T,
     {
-        let mut stack = vec![VPTreeBuilder::new(&mut self.root, lower, upper)];
-        let mut thread_rng = super::make_rng();
+        let n = self.items.len();
+        if n == 0 {
+            return;
+        }
 
-        while let Some(builder) = stack.pop() {
-            let VPTreeBuilder { root, lower, upper } = builder;
+        let mut rng = super::make_rng();
+        // Cached (distance, item) pairs for the current partition, reused across frames.
+        let mut partition: Vec<(T, (usize, &'a U))> = Vec::new();
+        let mut stack = vec![(0usize, n, SENTINEL, Side::Root)];
 
-            // Lower index is center of current node.
-            if upper != lower {
-                *root = Some(Box::new(Node::default()));
-                let node = root.as_deref_mut().unwrap();
-                node.index = lower;
+        while let Some((lower, upper, parent, side)) = stack.pop() {
+            // An empty range contributes no node; the parent's link stays SENTINEL.
+            if lower == upper {
+                continue;
+            }
 
-                if upper - lower > 1 {
-                    // If we did not arrive at leaf yet choose an arbitrary point
-                    // and move it to the start.
-                    let i = thread_rng.random_range(lower..upper);
-                    self.items.swap(lower, i);
+            // Allocate this node and wire it to its parent.
+            let node_index = self.nodes.len() as u32;
+            self.nodes.push(Node {
+                item: lower as u32,
+                ..Node::default()
+            });
+            match side {
+                Side::Root => {}
+                Side::Left => self.nodes[parent as usize].left = node_index,
+                Side::Right => self.nodes[parent as usize].right = node_index,
+            }
 
-                    let (_, to_cmp) = self.items[lower];
-                    // Partition around the median distances.
-                    let median: usize = (upper + lower) / 2;
-                    self.items[lower + 1..upper].select_nth_unstable_by(
-                        median - lower - 1,
-                        &mut |(_, a): &(usize, &U), (_, b): &(usize, &U)| {
-                            if metric_f(to_cmp, a) < metric_f(to_cmp, b) {
-                                Ordering::Less
-                            } else if metric_f(to_cmp, a) == metric_f(to_cmp, b) {
-                                Ordering::Equal
-                            } else {
-                                Ordering::Greater
-                            }
-                        },
-                    );
+            if upper - lower > 1 {
+                // Choose an arbitrary vantage point and move it to the start.
+                let i = rng.random_range(lower..upper);
+                self.items.swap(lower, i);
 
-                    // Threshold of the new node will be the distances to the median.
-                    node.threshold = metric_f(self.items[lower].1, self.items[median].1);
+                let vantage = self.items[lower].1;
+                let median = (upper + lower) / 2;
 
-                    stack.push(VPTreeBuilder::new(&mut node.left, lower + 1, median));
-                    stack.push(VPTreeBuilder::new(&mut node.right, median, upper));
+                // Cache the vantage-to-candidate distances once, then select the median on the
+                // cached scalars.
+                partition.clear();
+                partition.extend(
+                    self.items[lower + 1..upper]
+                        .iter()
+                        .map(|pair @ (_, sample)| (metric_f(vantage, sample), *pair)),
+                );
+                let k = median - lower - 1;
+                partition.select_nth_unstable_by(k, |(a, ..), (b, ..)| {
+                    a.partial_cmp(b).unwrap_or(Ordering::Equal)
+                });
+                // Write the partitioned order back into `items`.
+                for (slot, &(_, pair)) in self.items[lower + 1..upper]
+                    .iter_mut()
+                    .zip(partition.iter())
+                {
+                    *slot = pair;
                 }
+
+                // Threshold of the new node is the distance to the median.
+                self.nodes[node_index as usize].threshold = metric_f(vantage, self.items[median].1);
+
+                stack.push((lower + 1, median, node_index, Side::Left));
+                stack.push((median, upper, node_index, Side::Right));
             }
         }
     }
 
-    /// Auxiliary function that searches for the k nearest neighbors of an item.
+    /// Auxiliary function that searches for the k nearest neighbors of an item, accumulating them on
+    /// `heap`.
     fn look_up<F>(
         &self,
         tau: &mut T, // Tracks the distances to the farthest point in the results.
@@ -173,56 +180,55 @@ impl<'a, T: Float + Send + Sync, U> VPTree<'a, T, U> {
     ) where
         F: Fn(&U, &U) -> T,
     {
-        let mut stack: Vec<&Option<Box<Node<T>>>> = vec![&self.root];
+        if self.nodes.is_empty() {
+            return;
+        }
+        let mut stack: Vec<u32> = vec![0];
 
-        while let Some(next_in_stack) = stack.pop() {
-            if let Some(node) = next_in_stack {
-                let (original_position, point) = &self.items[node.index];
-                // Compute distances between target and current node.
-                let distance: T = metric_f(point, target);
-                if distance < *tau {
-                    // If current node is within the radius tau
-                    // remove furthest node from result list (if it already contains k results),
-                    // add current node to result list and
-                    // update value of tau (farthest point in result list).
-                    if heap.len() == k {
-                        heap.pop();
-                    }
-                    heap.push(HeapItem {
-                        index: *original_position,
-                        distance,
-                    });
-                    if heap.len() == k {
-                        *tau = heap.peek().unwrap().distance;
-                    }
+        while let Some(node_index) = stack.pop() {
+            let node = &self.nodes[node_index as usize];
+            let (original_position, point) = self.items[node.item as usize];
+            // Compute distances between target and current node.
+            let distance: T = metric_f(point, target);
+            if distance < *tau {
+                // If current node is within the radius tau
+                // remove furthest node from result list (if it already contains k results),
+                // add current node to result list and
+                // update value of tau (farthest point in result list).
+                if heap.len() == k {
+                    heap.pop();
                 }
+                heap.push(HeapItem {
+                    index: original_position,
+                    distance,
+                });
+                if heap.len() == k {
+                    *tau = heap.peek().unwrap().distance;
+                }
+            }
 
-                match (node.left.as_ref(), node.right.as_ref()) {
-                    // Return if we arrived at a leaf.
-                    (None, None) => continue,
-                    (_, _) => {
-                        // If the target lies within the radius of ball.
-                        if distance < node.threshold {
-                            // if there can still be neighbors inside the ball, recursively search left child first.
-                            if distance - *tau <= node.threshold {
-                                stack.push(&node.left)
-                            }
-                            // if there can still be neighbors outside the ball, recursively search right child.
-                            if distance + *tau >= node.threshold {
-                                stack.push(&node.right)
-                            }
-                        } else {
-                            // If the target lies outsize the radius of the ball.
-                            // If there can still be neighbors outside the ball, recursively search right child.
-                            if distance + *tau >= node.threshold {
-                                stack.push(&node.right)
-                            }
-                            // if there can still be neighbors inside the ball, recursively search left child.
-                            if distance - *tau <= node.threshold {
-                                stack.push(&node.left)
-                            }
-                        }
-                    }
+            // Return if we arrived at a leaf.
+            if node.left == SENTINEL && node.right == SENTINEL {
+                continue;
+            }
+
+            if distance < node.threshold {
+                // If the target lies within the radius of the ball, search the left (near) child
+                // first; the right (far) child only if neighbors could still lie outside the ball.
+                if distance + *tau >= node.threshold && node.right != SENTINEL {
+                    stack.push(node.right);
+                }
+                if distance - *tau <= node.threshold && node.left != SENTINEL {
+                    stack.push(node.left);
+                }
+            } else {
+                // If the target lies outside the radius of the ball, search the right (far) child
+                // first; the left (near) child only if neighbors could still lie inside the ball.
+                if distance - *tau <= node.threshold && node.left != SENTINEL {
+                    stack.push(node.left);
+                }
+                if distance + *tau >= node.threshold && node.right != SENTINEL {
+                    stack.push(node.right);
                 }
             }
         }
@@ -234,11 +240,11 @@ impl<'a, T: Float + Send + Sync, U> VPTree<'a, T, U> {
     ///
     /// * `target` -  target data point.
     ///
-    /// * `index` - index of the target.
+    /// * `target_index` - index of the target.
     ///
     /// * `k` - number of nearest neighbors.
     ///
-    /// * `results` - vector in which the index of the nearest neighbors will be saved.
+    /// * `neighbors_indices` - vector in which the index of the nearest neighbors will be saved.
     ///
     /// * `distances` - vector storing relative distances of the nearest neighbors.
     ///


### PR DESCRIPTION
Benches against current master:

```
Running benches/affinities.rs (target/release/deps/affinities-ac8c2c41e8f15a34)
input_affinities/vptree/500
                        time:   [7.2495 ms 7.2605 ms 7.2729 ms]
                        thrpt:  [68.749 Kelem/s 68.866 Kelem/s 68.970 Kelem/s]
                 change:
                        time:   [−17.650% −17.483% −17.296%] (p = 0.00 < 0.05)
                        thrpt:  [+20.913% +21.186% +21.433%]
                        Performance has improved.
Found 5 outliers among 100 measurements (5.00%)
  3 (3.00%) high mild
  2 (2.00%) high severe
input_affinities/precomputed_neighbors/500
                        time:   [3.7011 ms 3.7124 ms 3.7305 ms]
                        thrpt:  [134.03 Kelem/s 134.68 Kelem/s 135.10 Kelem/s]
                 change:
                        time:   [−4.5926% −4.2507% −3.8066%] (p = 0.00 < 0.05)
                        thrpt:  [+3.9572% +4.4394% +4.8136%]
                        Performance has improved.
Found 3 outliers among 100 measurements (3.00%)
  2 (2.00%) low mild
  1 (1.00%) high severe
input_affinities/vptree/1000
                        time:   [19.332 ms 19.372 ms 19.425 ms]
                        thrpt:  [51.481 Kelem/s 51.620 Kelem/s 51.728 Kelem/s]
                 change:
                        time:   [−14.876% −14.651% −14.390%] (p = 0.00 < 0.05)
                        thrpt:  [+16.809% +17.165% +17.475%]
                        Performance has improved.
Found 6 outliers among 100 measurements (6.00%)
  4 (4.00%) high mild
  2 (2.00%) high severe
input_affinities/precomputed_neighbors/1000
                        time:   [7.3604 ms 7.3696 ms 7.3784 ms]
                        thrpt:  [135.53 Kelem/s 135.69 Kelem/s 135.86 Kelem/s]
                 change:
                        time:   [−5.0597% −4.8317% −4.5916%] (p = 0.00 < 0.05)
                        thrpt:  [+4.8125% +5.0770% +5.3293%]
                        Performance has improved.
Found 10 outliers among 100 measurements (10.00%)
  3 (3.00%) low severe
  2 (2.00%) low mild
  5 (5.00%) high mild
Benchmarking input_affinities/vptree/2000: Warming up for 3.0000 s
Warning: Unable to complete 100 samples in 5.0s. You may wish to increase target time to 5.7s, or reduce sample count to 80.
input_affinities/vptree/2000
                        time:   [56.461 ms 56.567 ms 56.683 ms]
                        thrpt:  [35.284 Kelem/s 35.356 Kelem/s 35.423 Kelem/s]
                 change:
                        time:   [−12.240% −11.986% −11.726%] (p = 0.00 < 0.05)
                        thrpt:  [+13.284% +13.618% +13.948%]
                        Performance has improved.
Found 11 outliers among 100 measurements (11.00%)
  5 (5.00%) high mild
  6 (6.00%) high severe
input_affinities/precomputed_neighbors/2000
                        time:   [13.968 ms 13.988 ms 14.011 ms]
                        thrpt:  [142.75 Kelem/s 142.98 Kelem/s 143.19 Kelem/s]
                 change:
                        time:   [−4.1836% −4.0090% −3.8216%] (p = 0.00 < 0.05)
                        thrpt:  [+3.9734% +4.1764% +4.3663%]
                        Performance has improved.
Found 7 outliers among 100 measurements (7.00%)
  5 (5.00%) high mild
  2 (2.00%) high severe
Benchmarking input_affinities/vptree/4000: Warming up for 3.0000 s
Warning: Unable to complete 100 samples in 5.0s. You may wish to increase target time to 18.4s, or reduce sample count to 20.
input_affinities/vptree/4000
                        time:   [182.96 ms 183.57 ms 184.28 ms]
                        thrpt:  [21.706 Kelem/s 21.790 Kelem/s 21.863 Kelem/s]
                 change:
                        time:   [−8.3678% −7.9653% −7.5416%] (p = 0.00 < 0.05)
                        thrpt:  [+8.1567% +8.6547% +9.1320%]
                        Performance has improved.
Found 15 outliers among 100 measurements (15.00%)
  3 (3.00%) high mild
  12 (12.00%) high severe
input_affinities/precomputed_neighbors/4000
                        time:   [28.072 ms 28.139 ms 28.210 ms]
                        thrpt:  [141.80 Kelem/s 142.15 Kelem/s 142.49 Kelem/s]
                 change:
                        time:   [−3.0635% −2.7926% −2.5050%] (p = 0.00 < 0.05)
                        thrpt:  [+2.5694% +2.8729% +3.1603%]
                        Performance has improved.
Found 4 outliers among 100 measurements (4.00%)
  3 (3.00%) high mild
  1 (1.00%) high severe
```

I am aware that pre-computing neighbours using external faster methods is the current fast path, but this is an additive improvement that doesn't regress the existing path.

cc. @LucaCappelletti94 