### PR TITLE
Add 4D Barnes-Hut embedding

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## 0.7.10
+
+Add 4D support for the Barnes-Hut path: `barnes_hut` and `barnes_hut_with_neighbors` now accept an embedding dimensionality `D` of 4 (in addition to 2 and 3). The Morton codec uses 16 bits per axis at `D = 4`, so points closer than `1 / 65536` of the bounding-box width on any axis collapse into the same leaf cell.
+
 ## 0.7.4
 
 Add `tSNE::fit_sne` and `tSNE::fit_sne_with_neighbors`, an FFT-accelerated, interpolation-based fitting path (the FIt-SNE method of Linderman et al., 2019, the same algorithm openTSNE defaults to). It builds the sparse affinity graph exactly as `barnes_hut` does, sharing the vantage point tree, the per-point Gaussian bandwidth search, the symmetrization, and the affinity cache, but approximates the repulsive forces in `O(n)` per epoch on a coarse equispaced grid rather than over a space-partitioning tree, and carries no `theta` accuracy knob. The repulsive force and the `Q` normalizer are both recovered from one convolution with the squared Cauchy kernel via the `D + 2` term identity (charges `[1, y_1, ..., y_D, ||y||^2]`), matching openTSNE's formulation. Both produce the `negative_forces` and `Z` the Barnes-Hut loop expects, so the two repulsion strategies feed the very same fused gradient-descent update, which is now factored into a shared `gradient_descent_step`; the affinity construction is shared through a `build_affinities` helper.

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -67,6 +67,7 @@ plotters = { version = "0.3", default-features = false, features = [
 ] }
 npyz = { version = "0.9", features = ["npz"] }
 chrono = "0.4"
+proptest = "1"
 
 [[bench]]
 harness = false

--- a/README.md
+++ b/README.md
@@ -65,7 +65,7 @@ bhtsne::tSNE::<f32, &[f32], 2>::new(&samples)
 
 In the example euclidean distance is used, but any other distance metric on data types of choice, such as strings, can be defined and plugged in.
 
-The tree-accelerated `barnes_hut` and `barnes_hut_with_neighbors` support an embedding dimensionality `D` of 2 or 3, the dimensionalities a `u64` Z-order code covers with ample precision. The exact `exact` path stays general for any `D`.
+The tree-accelerated `barnes_hut` and `barnes_hut_with_neighbors` support an embedding dimensionality `D` of 2, 3, or 4, the dimensionalities a `u64` Z-order code covers with ample precision (32, 21, and 16 bits per axis, respectively). The exact `exact` path stays general for any `D`.
 
 ## FIt-SNE
 

--- a/src/repulsion.rs
+++ b/src/repulsion.rs
@@ -119,7 +119,7 @@ where
                     (
                         [T::zero(); D],
                         [T::zero(); D],
-                        [0u32; tsne::arena::STACK_CAP],
+                        <tsne::morton::Dim<D> as tsne::morton::Morton<D>>::empty_stack(),
                     )
                 },
                 |(edge_row, nonedge_row, stack),
@@ -137,7 +137,7 @@ where
                         y,
                         nonedge_row,
                         &mut q_sum,
-                        stack,
+                        stack.as_mut(),
                     );
                     positive_out.copy_from_slice(&edge_row[..]);
                     negative_out.copy_from_slice(&nonedge_row[..]);

--- a/src/test.rs
+++ b/src/test.rs
@@ -1896,3 +1896,21 @@ fn fit_sne_with_neighbors_rejects_out_of_range_index() {
         .epochs(1)
         .fit_sne_with_neighbors(&neighbors);
 }
+
+/// Smoke test for the 4D Barnes-Hut path: the embedding stays finite and correctly sized
+/// after a short fit.
+#[test]
+fn barnes_hut_runs_in_four_dimensions() {
+    const N: usize = 200;
+    const DIN: usize = 5;
+
+    let data = lcg_samples(N, DIN, 42);
+    let samples: Vec<&[f32]> = data.chunks(DIN).collect();
+    let mut tsne: tSNE<f32, &[f32], 4> = tSNE::new(&samples);
+    tsne.perplexity(PERPLEXITY)
+        .epochs(50)
+        .barnes_hut(THETA, |a, b| euclidean(a, b));
+    let embedding = tsne.embedding();
+    assert_eq!(embedding.len(), N * 4);
+    assert!(embedding.iter().all(|v| v.is_finite()));
+}

--- a/src/tsne/arena.rs
+++ b/src/tsne/arena.rs
@@ -26,13 +26,6 @@ const SENTINEL: u32 = u32::MAX;
 /// Slack fraction.
 const SLACK_FRACTION: f64 = 0.03;
 
-/// Capacity of the traversal stack. A root-to-leaf path crosses at most `BITS` internal cells (a
-/// child's level is strictly greater than its parent's), and each pushes at most `2^D - 1`
-/// unvisited siblings, so the live stack never exceeds `BITS * (2^D - 1)` plus one final fan-out.
-/// That is 96 at `D = 2` (32 bits) and 147 at `D = 3` (21 bits), so 256 holds both with margin.
-/// Kept fixed and stack-allocated so the repulsive traversal never touches the heap.
-pub(crate) const STACK_CAP: usize = 256;
-
 /// One cell of the arena. The Barnes-Hut traversal reads `center_of_mass`, `count`, and `level`
 /// (which sizes the cell through the per-tree half-width table), and follows `first_child` for the
 /// `child_count` children stored contiguously. A leaf is marked by `first_child == SENTINEL`.
@@ -49,7 +42,7 @@ struct Node<T, const D: usize> {
     level: u8,
 }
 
-/// A Morton linear quadtree (`D == 2`) or octree (`D == 3`) over the embedding, in one arena.
+/// A Morton linear quadtree (`D == 2`), octree (`D == 3`), or 16-cell tree (`D == 4`) over the embedding, in one arena.
 #[derive(Debug)]
 pub(crate) struct Arena<T, const D: usize> {
     nodes: Vec<Node<T, D>>,
@@ -331,7 +324,7 @@ where
 
     /// Accumulates the non-edge (repulsive) Barnes-Hut forces on point `index` into
     /// `negative_forces_row` and the normalization term `q_sum`. Iterative traversal over the arena
-    /// using `stack` as reusable scratch, a slice of at least [`STACK_CAP`] entries.
+    /// using `stack` as reusable scratch, a mutable slice of [`morton::Morton::Stack`].
     ///
     /// A node is summarized by its center of mass when it is a leaf or passes the theta test, and
     /// otherwise its children are pushed. The leaf holding the query's own point has zero distance
@@ -351,9 +344,8 @@ where
         }
         let (y_chunks, _) = y.as_chunks::<D>();
         let query = &y_chunks[index];
-
-        // Explicit stack with a local top cursor over `stack`, which holds at most `STACK_CAP`
-        // entries (see its bound). No heap allocation occurs on this hot path.
+        // Explicit stack with a local top cursor over `stack`, sized per dimensionality by
+        // `Morton::Stack`. No heap allocation occurs on this hot path.
         let mut top = 0usize;
         stack[top] = 0;
         top += 1;
@@ -566,7 +558,7 @@ mod tests {
         assert_eq!(arena.root_count(), 0);
         let mut forces = [0.0f32; 2];
         let mut q_sum = 0.0f32;
-        let mut stack = [0u32; STACK_CAP];
+        let mut stack = <Dim<2> as Morton<2>>::empty_stack();
         arena.compute_non_edge_forces(0, 0.25, &[], &mut forces, &mut q_sum, &mut stack);
         assert_eq!(forces, [0.0, 0.0]);
         assert_eq!(q_sum, 0.0);

--- a/src/tsne/mod.rs
+++ b/src/tsne/mod.rs
@@ -653,14 +653,14 @@ where
         q_sums.par_iter_mut().enumerate().for_each(|(index, sum)| {
             // Local scratch: the repulsive forces are not needed here, only their q_sum.
             let mut negative_forces = [T::zero(); D];
-            let mut stack = [0u32; arena::STACK_CAP];
+            let mut stack = <morton::Dim<D> as morton::Morton<D>>::empty_stack();
             arena.compute_non_edge_forces(
                 index,
                 theta_sq,
                 y,
                 &mut negative_forces,
                 sum,
-                &mut stack,
+                stack.as_mut(),
             );
         });
 

--- a/src/tsne/morton.rs
+++ b/src/tsne/morton.rs
@@ -2,21 +2,30 @@
 //!
 //! The arena encodes each embedding point as a single `u64` Morton code: the per-axis quantized
 //! coordinates are bit-interleaved so that sorting the codes lays the points out in Z-order, where
-//! points sharing a code prefix share a tree cell. Only `D in {2, 3}` are supported, the two
-//! dimensionalities a `u64` code covers with ample precision (32 bits per axis at `D = 2`, lossless
-//! for `f32`, and 21 bits per axis at `D = 3`). The [`Morton`] trait is implemented for those two
-//! dimensions alone, so the bound `Dim<D>: Morton<D>` is what restricts the Barnes-Hut tree path to
-//! `D in {2, 3}` at compile time.
+//! points sharing a code prefix share a tree cell. `D in {2, 3, 4}` are supported, covering a
+//! `u64` code with 32 bits per axis at `D = 2` (lossless for `f32`), 21 bits at `D = 3`, and
+//! 16 bits at `D = 4`. The [`Morton`] trait is implemented for those three dimensions, so the
+//! bound `Dim<D>: Morton<D>` is what restricts the Barnes-Hut tree path at compile time.
+
+mod d2;
+mod d3;
+mod d4;
 
 use num_traits::Float;
 
-/// Per-dimension Z-order codec, implemented only for [`Dim<2>`] and [`Dim<3>`].
+/// Per-dimension Z-order codec, implemented for [`Dim<2>`], [`Dim<3>`], and [`Dim<4>`].
 pub trait Morton<const D: usize> {
     /// Number of children a fully occupied internal cell can have, `2^D`.
     const CHILDREN: usize;
 
     /// Bits of precision per axis in the `u64` code.
     const BITS: u32;
+
+    /// Fixed-size traversal stack for the Barnes-Hut repulsive force pass.
+    type Stack: AsMut<[u32]>;
+
+    /// Allocate an empty stack on the caller's stack frame.
+    fn empty_stack() -> Self::Stack;
 
     /// Interleaves the `D` quantized per-axis coordinates into one Z-order code.
     fn encode(coords: [u32; D]) -> u64;
@@ -30,85 +39,6 @@ pub trait Morton<const D: usize> {
 /// Carrier type the per-`D` [`Morton`] implementations attach to, since a trait needs a type to
 /// dispatch on while `D` stays a const generic on the arena.
 pub struct Dim<const D: usize>;
-
-/// Spreads the low 32 bits of `x` into the even bit positions (one zero gap between each), the
-/// 2D Morton building block.
-#[inline]
-const fn part_1by1(mut x: u64) -> u64 {
-    x &= 0x0000_0000_ffff_ffff;
-    x = (x | (x << 16)) & 0x0000_ffff_0000_ffff;
-    x = (x | (x << 8)) & 0x00ff_00ff_00ff_00ff;
-    x = (x | (x << 4)) & 0x0f0f_0f0f_0f0f_0f0f;
-    x = (x | (x << 2)) & 0x3333_3333_3333_3333;
-
-    (x | (x << 1)) & 0x5555_5555_5555_5555
-}
-
-/// Inverse of [`part_1by1`]: gathers the even bit positions back into the low 32 bits.
-#[inline]
-const fn compact_1by1(mut x: u64) -> u64 {
-    x &= 0x5555_5555_5555_5555;
-    x = (x | (x >> 1)) & 0x3333_3333_3333_3333;
-    x = (x | (x >> 2)) & 0x0f0f_0f0f_0f0f_0f0f;
-    x = (x | (x >> 4)) & 0x00ff_00ff_00ff_00ff;
-    x = (x | (x >> 8)) & 0x0000_ffff_0000_ffff;
-
-    (x | (x >> 16)) & 0x0000_0000_ffff_ffff
-}
-
-/// Spreads the low 21 bits of `x` so each lands three positions apart, the 3D Morton building block.
-#[inline]
-const fn part_1by2(mut x: u64) -> u64 {
-    x &= 0x1f_ffff;
-    x = (x | (x << 32)) & 0x001f_0000_0000_ffff;
-    x = (x | (x << 16)) & 0x001f_0000_ff00_00ff;
-    x = (x | (x << 8)) & 0x100f_00f0_0f00_f00f;
-    x = (x | (x << 4)) & 0x10c3_0c30_c30c_30c3;
-
-    (x | (x << 2)) & 0x1249_2492_4924_9249
-}
-
-/// Inverse of [`part_1by2`]: gathers every third bit back into the low 21 bits.
-#[inline]
-const fn compact_1by2(mut x: u64) -> u64 {
-    x &= 0x1249_2492_4924_9249;
-    x = (x | (x >> 2)) & 0x10c3_0c30_c30c_30c3;
-    x = (x | (x >> 4)) & 0x100f_00f0_0f00_f00f;
-    x = (x | (x >> 8)) & 0x001f_0000_ff00_00ff;
-    x = (x | (x >> 16)) & 0x001f_0000_0000_ffff;
-
-    (x | (x >> 32)) & 0x001f_ffff
-}
-
-impl Morton<2> for Dim<2> {
-    const CHILDREN: usize = 4;
-    const BITS: u32 = 32;
-
-    fn encode([c0, c1]: [u32; 2]) -> u64 {
-        part_1by1(c0 as u64) | (part_1by1(c1 as u64) << 1)
-    }
-
-    fn decode(code: u64) -> [u32; 2] {
-        [compact_1by1(code) as u32, compact_1by1(code >> 1) as u32]
-    }
-}
-
-impl Morton<3> for Dim<3> {
-    const CHILDREN: usize = 8;
-    const BITS: u32 = 21;
-
-    fn encode([c0, c1, c2]: [u32; 3]) -> u64 {
-        part_1by2(c0 as u64) | (part_1by2(c1 as u64) << 1) | (part_1by2(c2 as u64) << 2)
-    }
-
-    fn decode(code: u64) -> [u32; 3] {
-        [
-            compact_1by2(code) as u32,
-            compact_1by2(code >> 1) as u32,
-            compact_1by2(code >> 2) as u32,
-        ]
-    }
-}
 
 /// Quantizes one embedding point to `B`-bit per-axis integer coordinates over the bounding box.
 ///
@@ -132,101 +62,4 @@ pub(crate) fn quantize<T: Float, const D: usize>(
             0
         }
     })
-}
-
-#[cfg(test)]
-mod tests {
-    use rand::{Rng, SeedableRng, rngs::StdRng};
-
-    use super::*;
-
-    #[test]
-    fn encode_decode_roundtrips_2d() {
-        let mut rng = StdRng::seed_from_u64(0x1234_5678);
-        for _ in 0..10_000 {
-            let x = rng.random::<u32>();
-            let y = rng.random::<u32>();
-            let code = Dim::<2>::encode([x, y]);
-            assert_eq!(Dim::<2>::decode(code), [x, y]);
-        }
-    }
-
-    #[test]
-    fn encode_decode_roundtrips_3d() {
-        let mut rng = StdRng::seed_from_u64(0x9abc_def0);
-        let mask = (1u32 << 21) - 1;
-        for _ in 0..10_000 {
-            let x = rng.random::<u32>() & mask;
-            let y = rng.random::<u32>() & mask;
-            let z = rng.random::<u32>() & mask;
-            let code = Dim::<3>::encode([x, y, z]);
-            assert_eq!(Dim::<3>::decode(code), [x, y, z]);
-        }
-    }
-
-    /// On a 2x2 grid the codes must be `0, 1, 2, 3` for `(0,0), (1,0), (0,1), (1,1)`, the canonical
-    /// Z-order with the first axis varying fastest.
-    #[test]
-    fn encode_matches_known_z_order_2d() {
-        assert_eq!(Dim::<2>::encode([0, 0]), 0);
-        assert_eq!(Dim::<2>::encode([1, 0]), 1);
-        assert_eq!(Dim::<2>::encode([0, 1]), 2);
-        assert_eq!(Dim::<2>::encode([1, 1]), 3);
-    }
-
-    #[test]
-    fn encode_matches_known_z_order_3d() {
-        assert_eq!(Dim::<3>::encode([0, 0, 0]), 0);
-        assert_eq!(Dim::<3>::encode([1, 0, 0]), 1);
-        assert_eq!(Dim::<3>::encode([0, 1, 0]), 2);
-        assert_eq!(Dim::<3>::encode([0, 0, 1]), 4);
-        assert_eq!(Dim::<3>::encode([1, 1, 1]), 7);
-    }
-
-    /// Sorting points by code must group them by shared high-bit prefix: two points in the same
-    /// top-level quadrant must sort adjacently relative to one in a different quadrant.
-    #[test]
-    fn sorting_by_code_yields_z_order() {
-        // Quantized so the top bit per axis selects the quadrant (bit 31 for D = 2).
-        let top = 1u32 << 31;
-        let lower_left = Dim::<2>::encode([1, 1]);
-        let lower_left_2 = Dim::<2>::encode([5, 7]);
-        let upper_right = Dim::<2>::encode([top, top]);
-        let mut codes = [upper_right, lower_left_2, lower_left];
-        codes.sort_unstable();
-        // The two lower-left points (small codes) precede the upper-right point.
-        assert!(codes[0] < codes[2]);
-        assert_eq!(codes[2], upper_right);
-        assert!(codes[0] == lower_left && codes[1] == lower_left_2);
-    }
-
-    /// Quantization maps the box corners to the first and last buckets and is monotone.
-    #[test]
-    fn quantize_spans_the_bucket_range() {
-        let min = [0.0f32, -2.0];
-        let extent = [4.0f32, 8.0];
-        let max_bucket = (1u64 << 32) - 1;
-        let inv_scale = [
-            (1u64 << 32) as f32 / extent[0],
-            (1u64 << 32) as f32 / extent[1],
-        ];
-        let low = quantize::<f32, 2>(&[0.0, -2.0], &min, &inv_scale, max_bucket as u32);
-        assert_eq!(low, [0, 0]);
-        let high = quantize::<f32, 2>(&[4.0, 6.0], &min, &inv_scale, max_bucket as u32);
-        assert_eq!(high, [max_bucket as u32, max_bucket as u32]);
-        let mid = quantize::<f32, 2>(&[2.0, 2.0], &min, &inv_scale, max_bucket as u32);
-        assert!(mid[0] > 0 && mid[0] < max_bucket as u32);
-        assert!(mid[1] > 0 && mid[1] < max_bucket as u32);
-    }
-
-    /// A degenerate zero-width axis collapses every point to bucket zero on that axis.
-    #[test]
-    fn quantize_handles_zero_width_axis() {
-        let min = [1.0f32, 5.0];
-        let inv_scale = [0.0f32, (1u64 << 32) as f32 / 4.0];
-        let max_bucket = ((1u64 << 32) - 1) as u32;
-        let q = quantize::<f32, 2>(&[1.0, 7.0], &min, &inv_scale, max_bucket);
-        assert_eq!(q[0], 0);
-        assert!(q[1] > 0);
-    }
 }

--- a/src/tsne/morton/d2.rs
+++ b/src/tsne/morton/d2.rs
@@ -1,0 +1,130 @@
+//! 2D Morton codec: 32 bits per axis (lossless for `f32`).
+
+use super::{Dim, Morton};
+
+/// Spreads the low 32 bits of `x` into the even bit positions (one zero gap between each), the
+/// 2D Morton building block.
+#[inline]
+const fn part_1by1(mut x: u64) -> u64 {
+    x &= 0x0000_0000_ffff_ffff;
+    x = (x | (x << 16)) & 0x0000_ffff_0000_ffff;
+    x = (x | (x << 8)) & 0x00ff_00ff_00ff_00ff;
+    x = (x | (x << 4)) & 0x0f0f_0f0f_0f0f_0f0f;
+    x = (x | (x << 2)) & 0x3333_3333_3333_3333;
+
+    (x | (x << 1)) & 0x5555_5555_5555_5555
+}
+
+/// Inverse of [`part_1by1`]: gathers the even bit positions back into the low 32 bits.
+#[inline]
+const fn compact_1by1(mut x: u64) -> u64 {
+    x &= 0x5555_5555_5555_5555;
+    x = (x | (x >> 1)) & 0x3333_3333_3333_3333;
+    x = (x | (x >> 2)) & 0x0f0f_0f0f_0f0f_0f0f;
+    x = (x | (x >> 4)) & 0x00ff_00ff_00ff_00ff;
+    x = (x | (x >> 8)) & 0x0000_ffff_0000_ffff;
+
+    (x | (x >> 16)) & 0x0000_0000_ffff_ffff
+}
+
+impl Morton<2> for Dim<2> {
+    const CHILDREN: usize = 4;
+    const BITS: u32 = 32;
+    type Stack = [u32; 128];
+
+    fn empty_stack() -> Self::Stack {
+        [0u32; 128]
+    }
+
+    fn encode([c0, c1]: [u32; 2]) -> u64 {
+        part_1by1(c0 as u64) | (part_1by1(c1 as u64) << 1)
+    }
+
+    fn decode(code: u64) -> [u32; 2] {
+        [compact_1by1(code) as u32, compact_1by1(code >> 1) as u32]
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use proptest::prop_assert_eq;
+    use rand::{Rng, SeedableRng, rngs::StdRng};
+
+    use super::super::{Dim, Morton, quantize};
+
+    #[test]
+    fn encode_decode_roundtrips_2d() {
+        let mut rng = StdRng::seed_from_u64(0x1234_5678);
+        for _ in 0..10_000 {
+            let x = rng.random::<u32>();
+            let y = rng.random::<u32>();
+            let code = Dim::<2>::encode([x, y]);
+            assert_eq!(Dim::<2>::decode(code), [x, y]);
+        }
+    }
+
+    /// On a 2x2 grid the codes must be `0, 1, 2, 3` for `(0,0), (1,0), (0,1), (1,1)`, the canonical
+    /// Z-order with the first axis varying fastest.
+    #[test]
+    fn encode_matches_known_z_order_2d() {
+        assert_eq!(Dim::<2>::encode([0, 0]), 0);
+        assert_eq!(Dim::<2>::encode([1, 0]), 1);
+        assert_eq!(Dim::<2>::encode([0, 1]), 2);
+        assert_eq!(Dim::<2>::encode([1, 1]), 3);
+    }
+
+    /// Sorting points by code must group them by shared high-bit prefix: two points in the same
+    /// top-level quadrant must sort adjacently relative to one in a different quadrant.
+    #[test]
+    fn sorting_by_code_yields_z_order() {
+        // Quantized so the top bit per axis selects the quadrant (bit 31 for D = 2).
+        let top = 1u32 << 31;
+        let lower_left = Dim::<2>::encode([1, 1]);
+        let lower_left_2 = Dim::<2>::encode([5, 7]);
+        let upper_right = Dim::<2>::encode([top, top]);
+        let mut codes = [upper_right, lower_left_2, lower_left];
+        codes.sort_unstable();
+        // The two lower-left points (small codes) precede the upper-right point.
+        assert!(codes[0] < codes[2]);
+        assert_eq!(codes[2], upper_right);
+        assert!(codes[0] == lower_left && codes[1] == lower_left_2);
+    }
+
+    /// Quantization maps the box corners to the first and last buckets and is monotone.
+    #[test]
+    fn quantize_spans_the_bucket_range() {
+        let min = [0.0f32, -2.0];
+        let extent = [4.0f32, 8.0];
+        let max_bucket = (1u64 << 32) - 1;
+        let inv_scale = [
+            (1u64 << 32) as f32 / extent[0],
+            (1u64 << 32) as f32 / extent[1],
+        ];
+        let low = quantize::<f32, 2>(&[0.0, -2.0], &min, &inv_scale, max_bucket as u32);
+        assert_eq!(low, [0, 0]);
+        let high = quantize::<f32, 2>(&[4.0, 6.0], &min, &inv_scale, max_bucket as u32);
+        assert_eq!(high, [max_bucket as u32, max_bucket as u32]);
+        let mid = quantize::<f32, 2>(&[2.0, 2.0], &min, &inv_scale, max_bucket as u32);
+        assert!(mid[0] > 0 && mid[0] < max_bucket as u32);
+        assert!(mid[1] > 0 && mid[1] < max_bucket as u32);
+    }
+
+    /// A degenerate zero-width axis collapses every point to bucket zero on that axis.
+    #[test]
+    fn quantize_handles_zero_width_axis() {
+        let min = [1.0f32, 5.0];
+        let inv_scale = [0.0f32, (1u64 << 32) as f32 / 4.0];
+        let max_bucket = ((1u64 << 32) - 1) as u32;
+        let q = quantize::<f32, 2>(&[1.0, 7.0], &min, &inv_scale, max_bucket);
+        assert_eq!(q[0], 0);
+        assert!(q[1] > 0);
+    }
+
+    proptest::proptest! {
+        #[test]
+        fn proptest_roundtrip_2d(x in 0u32.., y in 0u32..) {
+            let code = Dim::<2>::encode([x, y]);
+            prop_assert_eq!(Dim::<2>::decode(code), [x, y]);
+        }
+    }
+}

--- a/src/tsne/morton/d3.rs
+++ b/src/tsne/morton/d3.rs
@@ -1,0 +1,87 @@
+//! 3D Morton codec: 21 bits per axis.
+
+use super::{Dim, Morton};
+
+/// Spreads the low 21 bits of `x` so each lands three positions apart, the 3D Morton building block.
+#[inline]
+const fn part_1by2(mut x: u64) -> u64 {
+    x &= 0x1f_ffff;
+    x = (x | (x << 32)) & 0x001f_0000_0000_ffff;
+    x = (x | (x << 16)) & 0x001f_0000_ff00_00ff;
+    x = (x | (x << 8)) & 0x100f_00f0_0f00_f00f;
+    x = (x | (x << 4)) & 0x10c3_0c30_c30c_30c3;
+
+    (x | (x << 2)) & 0x1249_2492_4924_9249
+}
+
+/// Inverse of [`part_1by2`]: gathers every third bit back into the low 21 bits.
+#[inline]
+const fn compact_1by2(mut x: u64) -> u64 {
+    x &= 0x1249_2492_4924_9249;
+    x = (x | (x >> 2)) & 0x10c3_0c30_c30c_30c3;
+    x = (x | (x >> 4)) & 0x100f_00f0_0f00_f00f;
+    x = (x | (x >> 8)) & 0x001f_0000_ff00_00ff;
+    x = (x | (x >> 16)) & 0x001f_0000_0000_ffff;
+
+    (x | (x >> 32)) & 0x001f_ffff
+}
+
+impl Morton<3> for Dim<3> {
+    const CHILDREN: usize = 8;
+    const BITS: u32 = 21;
+    type Stack = [u32; 192];
+
+    fn empty_stack() -> Self::Stack {
+        [0u32; 192]
+    }
+
+    fn encode([c0, c1, c2]: [u32; 3]) -> u64 {
+        part_1by2(c0 as u64) | (part_1by2(c1 as u64) << 1) | (part_1by2(c2 as u64) << 2)
+    }
+
+    fn decode(code: u64) -> [u32; 3] {
+        [
+            compact_1by2(code) as u32,
+            compact_1by2(code >> 1) as u32,
+            compact_1by2(code >> 2) as u32,
+        ]
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use proptest::prop_assert_eq;
+    use rand::{Rng, SeedableRng, rngs::StdRng};
+
+    use super::super::{Dim, Morton};
+
+    #[test]
+    fn encode_decode_roundtrips_3d() {
+        let mut rng = StdRng::seed_from_u64(0x9abc_def0);
+        let mask = (1u32 << 21) - 1;
+        for _ in 0..10_000 {
+            let x = rng.random::<u32>() & mask;
+            let y = rng.random::<u32>() & mask;
+            let z = rng.random::<u32>() & mask;
+            let code = Dim::<3>::encode([x, y, z]);
+            assert_eq!(Dim::<3>::decode(code), [x, y, z]);
+        }
+    }
+
+    #[test]
+    fn encode_matches_known_z_order_3d() {
+        assert_eq!(Dim::<3>::encode([0, 0, 0]), 0);
+        assert_eq!(Dim::<3>::encode([1, 0, 0]), 1);
+        assert_eq!(Dim::<3>::encode([0, 1, 0]), 2);
+        assert_eq!(Dim::<3>::encode([0, 0, 1]), 4);
+        assert_eq!(Dim::<3>::encode([1, 1, 1]), 7);
+    }
+
+    proptest::proptest! {
+        #[test]
+        fn proptest_roundtrip_3d(x in 0u32..1 << 21, y in 0u32..1 << 21, z in 0u32..1 << 21) {
+            let code = Dim::<3>::encode([x, y, z]);
+            prop_assert_eq!(Dim::<3>::decode(code), [x, y, z]);
+        }
+    }
+}

--- a/src/tsne/morton/d4.rs
+++ b/src/tsne/morton/d4.rs
@@ -1,0 +1,91 @@
+//! 4D Morton codec: 16 bits per axis.
+
+use super::{Dim, Morton};
+
+/// Spreads the low 16 bits of `x` so each lands four positions apart, the 4D Morton building block.
+#[inline]
+const fn part_1by3(mut x: u64) -> u64 {
+    x &= 0x0000_0000_0000_ffff;
+    x = (x | (x << 24)) & 0x0000_00ff_0000_00ff;
+    x = (x | (x << 12)) & 0x000f_000f_000f_000f;
+    x = (x | (x << 6)) & 0x0303_0303_0303_0303;
+
+    (x | (x << 3)) & 0x1111_1111_1111_1111
+}
+
+/// Inverse of [`part_1by3`]: gathers every fourth bit back into the low 16 bits.
+#[inline]
+const fn compact_1by3(mut x: u64) -> u64 {
+    x &= 0x1111_1111_1111_1111;
+    x = (x | (x >> 3)) & 0x0303_0303_0303_0303;
+    x = (x | (x >> 6)) & 0x000f_000f_000f_000f;
+    x = (x | (x >> 12)) & 0x0000_00ff_0000_00ff;
+
+    (x | (x >> 24)) & 0x0000_0000_0000_ffff
+}
+
+impl Morton<4> for Dim<4> {
+    const CHILDREN: usize = 16;
+    const BITS: u32 = 16;
+    type Stack = [u32; 256];
+
+    fn empty_stack() -> Self::Stack {
+        [0u32; 256]
+    }
+
+    fn encode([c0, c1, c2, c3]: [u32; 4]) -> u64 {
+        part_1by3(c0 as u64)
+            | (part_1by3(c1 as u64) << 1)
+            | (part_1by3(c2 as u64) << 2)
+            | (part_1by3(c3 as u64) << 3)
+    }
+
+    fn decode(code: u64) -> [u32; 4] {
+        [
+            compact_1by3(code) as u32,
+            compact_1by3(code >> 1) as u32,
+            compact_1by3(code >> 2) as u32,
+            compact_1by3(code >> 3) as u32,
+        ]
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use proptest::prop_assert_eq;
+    use rand::{Rng, SeedableRng, rngs::StdRng};
+
+    use super::super::{Dim, Morton};
+
+    #[test]
+    fn encode_decode_roundtrips_4d() {
+        let mut rng = StdRng::seed_from_u64(0xabcd_1234);
+        let mask = (1u32 << 16) - 1;
+        for _ in 0..10_000 {
+            let a = rng.random::<u32>() & mask;
+            let b = rng.random::<u32>() & mask;
+            let c = rng.random::<u32>() & mask;
+            let d = rng.random::<u32>() & mask;
+            let code = Dim::<4>::encode([a, b, c, d]);
+            assert_eq!(Dim::<4>::decode(code), [a, b, c, d]);
+        }
+    }
+
+    #[test]
+    fn encode_matches_known_z_order_4d() {
+        assert_eq!(Dim::<4>::encode([0, 0, 0, 0]), 0);
+        assert_eq!(Dim::<4>::encode([1, 0, 0, 0]), 1);
+        assert_eq!(Dim::<4>::encode([0, 1, 0, 0]), 2);
+        assert_eq!(Dim::<4>::encode([0, 0, 1, 0]), 4);
+        assert_eq!(Dim::<4>::encode([0, 0, 0, 1]), 8);
+        assert_eq!(Dim::<4>::encode([1, 1, 1, 1]), 15);
+    }
+
+    proptest::proptest! {
+        #[test]
+        fn proptest_roundtrip_4d(a in 0u16.., b in 0u16.., c in 0u16.., d in 0u16..) {
+            let code = Dim::<4>::encode([a as u32, b as u32, c as u32, d as u32]);
+            prop_assert_eq!(Dim::<4>::decode(code), [a as u32, b as u32, c as u32, d as u32]);
+        }
+    }
+}


### PR DESCRIPTION
The tree-accelerated `barnes_hut` and `barnes_hut_with_neighbors` paths now accept an embedding dimensionality `D` of 4. The `Morton` trait gets a new `impl Morton<4>` with a stride-4 bit-spreader and 16 bits per axis, which saturates the `u64` code exactly.

The traversal stack is moved from a global `STACK_CAP` constant to a per-dimensionality associated type `Morton::Stack` (128, 192, and 256 entries for D = 2, 3, 4), allocated on the caller's stack frame via `Morton::empty_stack`. The Morton codec is split into per-dimension submodules under `morton/` to keep each spreader, its impl, and its tests collocated.

Points closer than `1 / 65536` of the bounding-box width on any axis collapse into the same leaf cell at D=4, which the shared-code leaf case handles correctly.