### PR TITLE
Add associated Word type to Morton<D> for generic Morton code size

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -435,13 +435,15 @@ where
                 &self.y,
                 n_samples,
             )),
-            Fit::BarnesHut { theta } => Some(BarnesHutRepulsion::<T, D>::new(*theta).error(
-                &self.p_rows,
-                &self.p_columns,
-                &self.p_values,
-                &self.y,
-                n_samples,
-            )),
+            Fit::BarnesHut { theta } => Some(
+                BarnesHutRepulsion::<T, <Dim<D> as Morton<D>>::Word, D>::new(*theta).error(
+                    &self.p_rows,
+                    &self.p_columns,
+                    &self.p_values,
+                    &self.y,
+                    n_samples,
+                ),
+            ),
             Fit::Interpolated => Some(InterpolatedRepulsion::<T, D>::new().error(
                 &self.p_rows,
                 &self.p_columns,
@@ -686,7 +688,7 @@ where
         if self.has_cached_affinities(n_samples) {
             return self.run_cached(
                 n_samples,
-                BarnesHutRepulsion::new(theta),
+                BarnesHutRepulsion::<T, <Dim<D> as Morton<D>>::Word, D>::new(theta),
                 Fit::BarnesHut { theta },
             );
         }
@@ -712,7 +714,7 @@ where
                     &metric_f,
                 );
             },
-            BarnesHutRepulsion::new(theta),
+            BarnesHutRepulsion::<T, <Dim<D> as Morton<D>>::Word, D>::new(theta),
             Fit::BarnesHut { theta },
         )
     }
@@ -742,7 +744,7 @@ where
         self.validate_fit_params(theta);
         self.approximate_fit_with_neighbors(
             neighbors,
-            BarnesHutRepulsion::new(theta),
+            BarnesHutRepulsion::<T, <Dim<D> as Morton<D>>::Word, D>::new(theta),
             Fit::BarnesHut { theta },
         )
     }

--- a/src/repulsion.rs
+++ b/src/repulsion.rs
@@ -56,9 +56,12 @@ pub(crate) trait Repulsion<T, const D: usize> {
 /// Barnes-Hut repulsion. A Morton arena summarizes the repulsive forces, computed in
 /// the same fused parallel pass as the attractive forces and the per-sample `Q`
 /// contributions, the latter reduced into `Z` afterwards.
-pub(crate) struct BarnesHutRepulsion<T, const D: usize> {
+pub(crate) struct BarnesHutRepulsion<T, W, const D: usize>
+where
+    W: tsne::morton::MortonWord,
+{
     /// Morton arena, rebuilt over the embedding each epoch so its buffers persist.
-    arena: tsne::arena::Arena<T, D>,
+    arena: tsne::arena::Arena<T, W, D>,
     /// Per-sample contribution to the `Q` normalizer, reduced after the force pass.
     /// Sized to the sample count on the first epoch and reused thereafter.
     q_sums: Vec<T>,
@@ -68,9 +71,10 @@ pub(crate) struct BarnesHutRepulsion<T, const D: usize> {
     theta_sq: T,
 }
 
-impl<T, const D: usize> BarnesHutRepulsion<T, D>
+impl<T, W, const D: usize> BarnesHutRepulsion<T, W, D>
 where
     T: Float + Send + Sync + AddAssign,
+    W: tsne::morton::MortonWord,
 {
     pub(crate) fn new(theta: T) -> Self {
         Self {
@@ -82,10 +86,11 @@ where
     }
 }
 
-impl<T, const D: usize> Repulsion<T, D> for BarnesHutRepulsion<T, D>
+impl<T, W, const D: usize> Repulsion<T, D> for BarnesHutRepulsion<T, W, D>
 where
     T: Float + Send + Sync + Sum + AddAssign + SubAssign + MulAssign + DivAssign,
-    tsne::morton::Dim<D>: tsne::morton::Morton<D>,
+    W: tsne::morton::MortonWord,
+    tsne::morton::Dim<D>: tsne::morton::Morton<D, Word = W>,
 {
     fn step(
         &mut self,

--- a/src/test.rs
+++ b/src/test.rs
@@ -1169,7 +1169,7 @@ fn arena_build_maintains_invariants() {
         *value += 100.0;
     }
 
-    let arena = tsne::arena::Arena::<f32, 2>::new(&data, N);
+    let arena = tsne::arena::Arena::<f32, u64, 2>::new(&data, N);
 
     assert_eq!(arena.root_count(), N, "arena lost or invented points");
 }

--- a/src/tsne/arena.rs
+++ b/src/tsne/arena.rs
@@ -2,10 +2,10 @@
 //! loop summarizes repulsive forces over.
 //!
 //! Every cell lives in one [`Vec<Node>`]. The build quantizes the embedding into per-axis integer
-//! coordinates, interleaves them into `u64` Morton codes, sorts a `(code, index)` permutation, and
-//! walks the sorted codes breadth first to emit nodes whose children occupy a contiguous arena
-//! range reached through `first_child`. A cell stores only the summary the traversal reads (center
-//! of mass, count, level), never raw coordinates.
+//! coordinates, interleaves them into Morton codes, sorts a `(code, index)` permutation, and walks
+//! the sorted codes breadth first to emit nodes whose children occupy a contiguous arena range
+//! reached through `first_child`. A cell stores only the summary the traversal reads (center of
+//! mass, count, level), never raw coordinates.
 //!
 //! Morton quantization is total, so every point maps to exactly one cell and point conservation is
 //! automatic, which the build asserts (leaf masses sum to `n`).
@@ -18,7 +18,7 @@ use rayon::prelude::*;
 
 use crate::PARALLEL_CODE_THRESHOLD;
 
-use super::morton::{Dim, Morton, quantize};
+use super::morton::{Dim, Morton, MortonWord, quantize};
 
 /// `first_child` value marking a leaf, a node with no children in the arena.
 const SENTINEL: u32 = u32::MAX;
@@ -42,15 +42,19 @@ struct Node<T, const D: usize> {
     level: u8,
 }
 
-/// A Morton linear quadtree (`D == 2`), octree (`D == 3`), or 16-cell tree (`D == 4`) over the embedding, in one arena.
+/// A Morton linear quadtree (`D == 2`), octree (`D == 3`), or 16-cell tree (`D == 4`) over the
+/// embedding, in one arena. `W` is the Morton word type (e.g. `u64` for D in {2,3,4}).
 #[derive(Debug)]
-pub(crate) struct Arena<T, const D: usize> {
+pub(crate) struct Arena<T, W, const D: usize>
+where
+    W: MortonWord,
+{
     nodes: Vec<Node<T, D>>,
     /// Build scratch: each emitted node's half-open window in `sorted`. Retained with `nodes` so a
     /// rebuild reuses the allocation rather than reallocating it every epoch.
     ranges: Vec<(u32, u32)>,
     /// The `(Morton code, point index)` permutation, retained across rebuilds to reuse its allocation.
-    sorted: Vec<(u64, u32)>,
+    sorted: Vec<(W, u32)>,
     /// Squared maximum half-width of a cell at each level, indexed by `Node::level`. The theta
     /// acceptance test compares this against `theta^2 * dist`, the squared form of the reference
     /// `max_half_width / sqrt(dist) < theta`, avoiding a square root per visit.
@@ -89,9 +93,10 @@ where
         )
 }
 
-impl<T, const D: usize> Arena<T, D>
+impl<T, W, const D: usize> Arena<T, W, D>
 where
     T: Float + Send + Sync + AddAssign,
+    W: MortonWord,
 {
     /// Creates an empty arena. The epoch loop holds one of these and rebuilds it each epoch so the
     /// buffers persist and are reused.
@@ -114,7 +119,7 @@ where
     /// build always satisfies.
     pub(crate) fn new(y: &[T], n_samples: usize) -> Self
     where
-        Dim<D>: Morton<D>,
+        Dim<D>: Morton<D, Word = W>,
     {
         let mut arena = Self::empty();
         arena.rebuild(y, n_samples);
@@ -131,7 +136,7 @@ where
     /// build always satisfies.
     pub(crate) fn rebuild(&mut self, y: &[T], n_samples: usize)
     where
-        Dim<D>: Morton<D>,
+        Dim<D>: Morton<D, Word = W>,
     {
         let bits = <Dim<D> as Morton<D>>::BITS;
 
@@ -206,7 +211,7 @@ where
         });
         ranges.push((0, n_samples as u32));
 
-        let mask = (1u64 << D) - 1;
+        let mask = W::d_bit_mask(D as u32);
         let mut node = 0usize;
         while node < nodes.len() {
             let (start, end) = ranges[node];
@@ -221,7 +226,7 @@ where
             // sits in the D-bit group that first splits the range, so the node skips straight to
             // that level rather than emitting single-child chains.
             let xor = sorted[start as usize].0 ^ sorted[(end - 1) as usize].0;
-            let highest_diff = 63 - xor.leading_zeros();
+            let highest_diff = xor.msb_position();
             let level = (bits - 1) - highest_diff / D as u32;
             let shift = D as u32 * (bits - 1 - level);
             nodes[node].level = level as u8;
@@ -317,7 +322,7 @@ where
             "arena lost or invented points"
         );
 
-        debug_assert!(check_coms_within_cells::<T, D>(
+        debug_assert!(check_coms_within_cells::<T, W, D>(
             nodes, ranges, sorted, &min, &extent, bits
         ));
     }
@@ -424,17 +429,18 @@ pub(crate) fn compute_edge_forces<T, const D: usize>(
 /// Whether every node's center of mass lies inside its Morton cell. Used only at build time in
 /// debug builds. Derives each cell from a representative member code, the node level, and the
 /// bounding box, so it needs the still-live sorted codes and ranges rather than per-node storage.
-fn check_coms_within_cells<T, const D: usize>(
+fn check_coms_within_cells<T, W, const D: usize>(
     nodes: &[Node<T, D>],
     ranges: &[(u32, u32)],
-    sorted: &[(u64, u32)],
+    sorted: &[(W, u32)],
     min: &[T; D],
     extent: &[T; D],
     bits: u32,
 ) -> bool
 where
     T: Float,
-    Dim<D>: Morton<D>,
+    W: MortonWord,
+    Dim<D>: Morton<D, Word = W>,
 {
     let slack_fraction = T::from(SLACK_FRACTION).unwrap();
 
@@ -457,7 +463,10 @@ where
 }
 
 #[cfg(test)]
-impl<T, const D: usize> Arena<T, D> {
+impl<T, W, const D: usize> Arena<T, W, D>
+where
+    W: MortonWord,
+{
     /// Number of points the arena holds, the root mass. Used by the build-invariant tests, where
     /// it crosses into a sibling module that cannot reach the private node array.
     pub(crate) fn root_count(&self) -> usize {
@@ -503,7 +512,7 @@ mod tests {
         for value in data.iter_mut() {
             *value += 100.0;
         }
-        let arena = Arena::<f32, 2>::new(&data, N);
+        let arena = Arena::<f32, u64, 2>::new(&data, N);
         assert_eq!(arena.root_count(), N);
     }
 
@@ -511,7 +520,7 @@ mod tests {
     fn build_conserves_points_3d() {
         const N: usize = 1_500;
         let data = lcg_cloud(N, 3, 23);
-        let arena = Arena::<f32, 3>::new(&data, N);
+        let arena = Arena::<f32, u64, 3>::new(&data, N);
         assert_eq!(arena.root_count(), N);
     }
 
@@ -520,7 +529,7 @@ mod tests {
     fn root_center_of_mass_equals_the_mean() {
         const N: usize = 1_000;
         let data = lcg_cloud(N, 2, 5);
-        let arena = Arena::<f32, 2>::new(&data, N);
+        let arena = Arena::<f32, u64, 2>::new(&data, N);
         let expected = mean::<2>(&data, N);
         let root = &arena.nodes[0];
         assert!((root.center_of_mass[0] - expected[0]).abs() < 1e-3);
@@ -533,7 +542,7 @@ mod tests {
     fn duplicate_points_collapse_to_one_leaf() {
         const N: usize = 500;
         let data = vec![3.5f32; N * 2];
-        let arena = Arena::<f32, 2>::new(&data, N);
+        let arena = Arena::<f32, u64, 2>::new(&data, N);
         assert_eq!(arena.root_count(), N);
         // All identical: the root itself is the single collapsed leaf.
         assert_eq!(arena.nodes.len(), 1);
@@ -545,7 +554,7 @@ mod tests {
     #[test]
     fn single_point_builds_a_leaf_root() {
         let data = [2.0f32, -1.0];
-        let arena = Arena::<f32, 2>::new(&data, 1);
+        let arena = Arena::<f32, u64, 2>::new(&data, 1);
         assert_eq!(arena.root_count(), 1);
         assert_eq!(arena.nodes.len(), 1);
         assert_eq!(arena.nodes[0].center_of_mass, [2.0, -1.0]);
@@ -554,7 +563,7 @@ mod tests {
     /// An empty input builds an empty arena and the force pass is a no-op.
     #[test]
     fn empty_input_builds_empty_arena() {
-        let arena = Arena::<f32, 2>::new(&[], 0);
+        let arena = Arena::<f32, u64, 2>::new(&[], 0);
         assert_eq!(arena.root_count(), 0);
         let mut forces = [0.0f32; 2];
         let mut q_sum = 0.0f32;

--- a/src/tsne/mod.rs
+++ b/src/tsne/mod.rs
@@ -646,7 +646,8 @@ where
 {
     // Get estimate of normalization term.
     let q_sum = {
-        let arena = arena::Arena::<T, D>::new(y, n_samples);
+        let arena =
+            arena::Arena::<T, <morton::Dim<D> as morton::Morton<D>>::Word, D>::new(y, n_samples);
         let theta_sq = theta * theta;
         let mut q_sums: Vec<T> = vec![T::zero(); n_samples];
 

--- a/src/tsne/morton.rs
+++ b/src/tsne/morton.rs
@@ -1,11 +1,11 @@
 //! Z-order (Morton) bit interleaving for the linear quadtree arena.
 //!
-//! The arena encodes each embedding point as a single `u64` Morton code: the per-axis quantized
+//! The arena encodes each embedding point as a single Morton code: the per-axis quantized
 //! coordinates are bit-interleaved so that sorting the codes lays the points out in Z-order, where
-//! points sharing a code prefix share a tree cell. `D in {2, 3, 4}` are supported, covering a
-//! `u64` code with 32 bits per axis at `D = 2` (lossless for `f32`), 21 bits at `D = 3`, and
-//! 16 bits at `D = 4`. The [`Morton`] trait is implemented for those three dimensions, so the
-//! bound `Dim<D>: Morton<D>` is what restricts the Barnes-Hut tree path at compile time.
+//! points sharing a code prefix share a tree cell. `D in {2, 3, 4}` are supported, with 32 bits
+//! per axis at `D = 2` (lossless for `f32`), 21 bits at `D = 3`, and 16 bits at `D = 4`. The
+//! [`Morton`] trait is implemented for those three dimensions, so the bound `Dim<D>: Morton<D>` is
+//! what restricts the Barnes-Hut tree path at compile time.
 
 mod d2;
 mod d3;
@@ -13,27 +13,78 @@ mod d4;
 
 use num_traits::Float;
 
+/// Integer type of a Morton code. Covers the operations the arena performs on codes: XOR, shifts,
+/// masks, comparison, and finding the most-significant differing bit.
+pub trait MortonWord:
+    Send
+    + Sync
+    + Copy
+    + Default
+    + Ord
+    + std::ops::BitXor<Output = Self>
+    + std::ops::BitAnd<Output = Self>
+    + std::ops::Shr<u32, Output = Self>
+{
+    /// Total number of bits in the type.
+    const BITS: u32;
+
+    /// Index of the most-significant set bit (0-based from the LSB).
+    ///
+    /// Returns `Self::BITS - 1` when the value is zero (no bits set).
+    fn msb_position(self) -> u32;
+
+    /// Returns a value with the low `d` bits set (a D-bit group mask).
+    fn d_bit_mask(d: u32) -> Self;
+}
+
+impl MortonWord for u64 {
+    const BITS: u32 = 64;
+    #[inline]
+    fn d_bit_mask(d: u32) -> Self {
+        (1u64 << d) - 1
+    }
+    #[inline]
+    fn msb_position(self) -> u32 {
+        Self::BITS - 1 - self.leading_zeros()
+    }
+}
+
+impl MortonWord for u128 {
+    const BITS: u32 = 128;
+
+    #[inline]
+    fn d_bit_mask(d: u32) -> Self {
+        (1u128 << d) - 1
+    }
+    fn msb_position(self) -> u32 {
+        Self::BITS - 1 - self.leading_zeros()
+    }
+}
+
 /// Per-dimension Z-order codec, implemented for [`Dim<2>`], [`Dim<3>`], and [`Dim<4>`].
 pub trait Morton<const D: usize> {
     /// Number of children a fully occupied internal cell can have, `2^D`.
     const CHILDREN: usize;
 
-    /// Bits of precision per axis in the `u64` code.
+    /// Bits of precision per axis in the Morton code.
     const BITS: u32;
 
     /// Fixed-size traversal stack for the Barnes-Hut repulsive force pass.
     type Stack: AsMut<[u32]>;
 
+    /// The integer type of the interleaved Morton code.
+    type Word: MortonWord;
+
     /// Allocate an empty stack on the caller's stack frame.
     fn empty_stack() -> Self::Stack;
 
     /// Interleaves the `D` quantized per-axis coordinates into one Z-order code.
-    fn encode(coords: [u32; D]) -> u64;
+    fn encode(coords: [u32; D]) -> Self::Word;
 
     /// Inverse of [`encode`], recovering the per-axis quantized coordinates.
     ///
     /// [`encode`]: Morton::encode
-    fn decode(code: u64) -> [u32; D];
+    fn decode(code: Self::Word) -> [u32; D];
 }
 
 /// Carrier type the per-`D` [`Morton`] implementations attach to, since a trait needs a type to

--- a/src/tsne/morton/d2.rs
+++ b/src/tsne/morton/d2.rs
@@ -31,16 +31,17 @@ impl Morton<2> for Dim<2> {
     const CHILDREN: usize = 4;
     const BITS: u32 = 32;
     type Stack = [u32; 128];
+    type Word = u64;
 
     fn empty_stack() -> Self::Stack {
         [0u32; 128]
     }
 
-    fn encode([c0, c1]: [u32; 2]) -> u64 {
+    fn encode([c0, c1]: [u32; 2]) -> Self::Word {
         part_1by1(c0 as u64) | (part_1by1(c1 as u64) << 1)
     }
 
-    fn decode(code: u64) -> [u32; 2] {
+    fn decode(code: Self::Word) -> [u32; 2] {
         [compact_1by1(code) as u32, compact_1by1(code >> 1) as u32]
     }
 }

--- a/src/tsne/morton/d3.rs
+++ b/src/tsne/morton/d3.rs
@@ -30,16 +30,17 @@ impl Morton<3> for Dim<3> {
     const CHILDREN: usize = 8;
     const BITS: u32 = 21;
     type Stack = [u32; 192];
+    type Word = u64;
 
     fn empty_stack() -> Self::Stack {
         [0u32; 192]
     }
 
-    fn encode([c0, c1, c2]: [u32; 3]) -> u64 {
+    fn encode([c0, c1, c2]: [u32; 3]) -> Self::Word {
         part_1by2(c0 as u64) | (part_1by2(c1 as u64) << 1) | (part_1by2(c2 as u64) << 2)
     }
 
-    fn decode(code: u64) -> [u32; 3] {
+    fn decode(code: Self::Word) -> [u32; 3] {
         [
             compact_1by2(code) as u32,
             compact_1by2(code >> 1) as u32,

--- a/src/tsne/morton/d4.rs
+++ b/src/tsne/morton/d4.rs
@@ -28,19 +28,20 @@ impl Morton<4> for Dim<4> {
     const CHILDREN: usize = 16;
     const BITS: u32 = 16;
     type Stack = [u32; 256];
+    type Word = u64;
 
     fn empty_stack() -> Self::Stack {
         [0u32; 256]
     }
 
-    fn encode([c0, c1, c2, c3]: [u32; 4]) -> u64 {
+    fn encode([c0, c1, c2, c3]: [u32; 4]) -> Self::Word {
         part_1by3(c0 as u64)
             | (part_1by3(c1 as u64) << 1)
             | (part_1by3(c2 as u64) << 2)
             | (part_1by3(c3 as u64) << 3)
     }
 
-    fn decode(code: u64) -> [u32; 4] {
+    fn decode(code: Self::Word) -> [u32; 4] {
         [
             compact_1by3(code) as u32,
             compact_1by3(code >> 1) as u32,


### PR DESCRIPTION
Adds an associated type \`Word\` to the \`Morton<D>\` trait so that \`encode\` and \`decode\` return/accept \`Self::Word\` instead of hard-coded \`u64\`. This is a prerequisite for D=5 and D=6 support, which need \`u128\` Morton codes (D=5 at 13 bits per axis exceeds 64 bits).

A new \`MortonWord\` trait captures the operations the arena performs on codes: \`BitXor\`, \`BitAnd\`, \`Shr<u32>\`, \`Ord\`, and \`msb_position\` (the generic replacement for \`leading_zeros\`). It is implemented for both \`u64\` and \`u128\`. The existing D=2, 3, 4 implementations keep \`type Word = u64\`.

The \`Arena\` struct and \`BarnesHutRepulsion\` are now generic over the word type \`W\`, threaded through all call sites via \`<Dim<D> as Morton<D>>::Word\`.