### PR TITLE
Add 5D Barnes-Hut support with u128 Morton codes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,10 @@
 # Changelog
 
-## 0.7.10
+## 0.7.11
 
+Add 5D support for the Barnes-Hut path: `barnes_hut` and `barnes_hut_with_neighbors` now accept an embedding dimensionality `D` of 5 (in addition to 2, 3, and 4). The Morton codec uses 25 bits per axis at `D = 5`, with a `u128` Z-order code (125 bits used), so points closer than `1 / 33554432` of the bounding-box width on any axis collapse into the same leaf cell.
+
+## 0.7.10
 Add 4D support for the Barnes-Hut path: `barnes_hut` and `barnes_hut_with_neighbors` now accept an embedding dimensionality `D` of 4 (in addition to 2 and 3). The Morton codec uses 16 bits per axis at `D = 4`, so points closer than `1 / 65536` of the bounding-box width on any axis collapse into the same leaf cell.
 
 ## 0.7.4

--- a/README.md
+++ b/README.md
@@ -65,7 +65,7 @@ bhtsne::tSNE::<f32, &[f32], 2>::new(&samples)
 
 In the example euclidean distance is used, but any other distance metric on data types of choice, such as strings, can be defined and plugged in.
 
-The tree-accelerated `barnes_hut` and `barnes_hut_with_neighbors` support an embedding dimensionality `D` of 2, 3, or 4, the dimensionalities a `u64` Z-order code covers with ample precision (32, 21, and 16 bits per axis, respectively). The exact `exact` path stays general for any `D`.
+The tree-accelerated `barnes_hut` and `barnes_hut_with_neighbors` support an embedding dimensionality `D` of 2, 3, 4, or 5, the dimensionalities a Z-order code covers with ample precision (32, 21, 16, and 25 bits per axis, respectively). The exact `exact` path stays general for any `D`.
 
 ## FIt-SNE
 

--- a/src/test.rs
+++ b/src/test.rs
@@ -1174,6 +1174,15 @@ fn arena_build_maintains_invariants() {
     assert_eq!(arena.root_count(), N, "arena lost or invented points");
 }
 
+/// Verify the 5D Morton codec and arena path compile and function correctly.
+#[test]
+fn arena_builds_5d() {
+    const N: usize = 500;
+    let data = lcg_samples(N, 5, 42);
+    let arena = tsne::arena::Arena::<f32, u128, 5>::new(&data, N);
+    assert_eq!(arena.root_count(), N);
+}
+
 /// End-to-end regression test for the same bug, reproducing the symptom directly: corrupted
 /// repulsive forces let attraction collapse the whole embedding onto a handful of coordinates. A
 /// healthy run spreads the points out, so most embedded positions are distinct.
@@ -1912,5 +1921,41 @@ fn barnes_hut_runs_in_four_dimensions() {
         .barnes_hut(THETA, |a, b| euclidean(a, b));
     let embedding = tsne.embedding();
     assert_eq!(embedding.len(), N * 4);
+    assert!(embedding.iter().all(|v| v.is_finite()));
+}
+
+/// Smoke test for the 3D Barnes-Hut path: the embedding stays finite and correctly sized
+/// after a short fit.
+#[test]
+fn barnes_hut_runs_in_three_dimensions() {
+    const N: usize = 200;
+    const DIN: usize = 5;
+
+    let data = lcg_samples(N, DIN, 43);
+    let samples: Vec<&[f32]> = data.chunks(DIN).collect();
+    let mut tsne: tSNE<f32, &[f32], 3> = tSNE::new(&samples);
+    tsne.perplexity(PERPLEXITY)
+        .epochs(50)
+        .barnes_hut(THETA, |a, b| euclidean(a, b));
+    let embedding = tsne.embedding();
+    assert_eq!(embedding.len(), N * 3);
+    assert!(embedding.iter().all(|v| v.is_finite()));
+}
+
+/// Smoke test for the 5D Barnes-Hut path: the embedding stays finite and correctly sized
+/// after a short fit.
+#[test]
+fn barnes_hut_runs_in_five_dimensions() {
+    const N: usize = 200;
+    const DIN: usize = 6;
+
+    let data = lcg_samples(N, DIN, 44);
+    let samples: Vec<&[f32]> = data.chunks(DIN).collect();
+    let mut tsne: tSNE<f32, &[f32], 5> = tSNE::new(&samples);
+    tsne.perplexity(PERPLEXITY)
+        .epochs(50)
+        .barnes_hut(THETA, |a, b| euclidean(a, b));
+    let embedding = tsne.embedding();
+    assert_eq!(embedding.len(), N * 5);
     assert!(embedding.iter().all(|v| v.is_finite()));
 }

--- a/src/tsne/morton.rs
+++ b/src/tsne/morton.rs
@@ -2,14 +2,15 @@
 //!
 //! The arena encodes each embedding point as a single Morton code: the per-axis quantized
 //! coordinates are bit-interleaved so that sorting the codes lays the points out in Z-order, where
-//! points sharing a code prefix share a tree cell. `D in {2, 3, 4}` are supported, with 32 bits
-//! per axis at `D = 2` (lossless for `f32`), 21 bits at `D = 3`, and 16 bits at `D = 4`. The
-//! [`Morton`] trait is implemented for those three dimensions, so the bound `Dim<D>: Morton<D>` is
-//! what restricts the Barnes-Hut tree path at compile time.
+//! points sharing a code prefix share a tree cell. `D in {2, 3, 4, 5}` are supported, with 32 bits
+//! per axis at `D = 2` (lossless for `f32`), 21 bits at `D = 3`, 16 bits at `D = 4`, and 25 bits
+//! at `D = 5`. The [`Morton`] trait is implemented for those four dimensions, so the bound
+//! `Dim<D>: Morton<D>` is what restricts the Barnes-Hut tree path at compile time.
 
 mod d2;
 mod d3;
 mod d4;
+mod d5;
 
 use num_traits::Float;
 
@@ -61,7 +62,7 @@ impl MortonWord for u128 {
     }
 }
 
-/// Per-dimension Z-order codec, implemented for [`Dim<2>`], [`Dim<3>`], and [`Dim<4>`].
+/// Per-dimension Z-order codec, implemented for [`Dim<2>`], [`Dim<3>`], [`Dim<4>`], and [`Dim<5>`].
 pub trait Morton<const D: usize> {
     /// Number of children a fully occupied internal cell can have, `2^D`.
     const CHILDREN: usize;

--- a/src/tsne/morton/d5.rs
+++ b/src/tsne/morton/d5.rs
@@ -1,0 +1,157 @@
+//! 5D Morton codec: 25 bits per axis.
+//!
+//! Uses a lookup table for the bit spreader since the final gap of 4 (five positions apart) does
+//! not decompose as powers of two, which breaks the standard binary-doubling shift-and-mask
+//! algorithm used for D in {2, 3, 4}.
+//!
+//! The 25 bits are split into six 4-bit nibbles (24 bits) plus one remaining bit. Each nibble is
+//! spread via a small lookup table and the results are concatenated at 20-bit offsets. The final
+//! interleaved code uses 125 bits (25 * 5), fitting in `u128`.
+
+use super::{Dim, Morton};
+
+/// Spreads the low 25 bits of `x` so each lands five positions apart (four gaps), the 5D Morton
+/// building block.
+///
+/// The low 24 bits are split into six 4-bit nibbles. Each nibble is spread via a lookup table
+/// and the six results are concatenated at 20-bit offsets. Bit 24 is placed directly at position
+/// 120.
+#[inline]
+const fn part_1by4(x: u128) -> u128 {
+    // Spread table for a single 4-bit nibble: bit i at position 5*i.
+    const SPREAD: [u128; 16] = [
+        0x0000_0000_0000_0000,
+        0x0000_0000_0000_0001,
+        0x0000_0000_0000_0020,
+        0x0000_0000_0000_0021,
+        0x0000_0000_0000_0400,
+        0x0000_0000_0000_0401,
+        0x0000_0000_0000_0420,
+        0x0000_0000_0000_0421,
+        0x0000_0000_0000_8000,
+        0x0000_0000_0000_8001,
+        0x0000_0000_0000_8020,
+        0x0000_0000_0000_8021,
+        0x0000_0000_0000_8400,
+        0x0000_0000_0000_8401,
+        0x0000_0000_0000_8420,
+        0x0000_0000_0000_8421,
+    ];
+
+    let x = x & 0x01_ff_ff_ff;
+    let n0 = x & 0xf;
+    let n1 = (x >> 4) & 0xf;
+    let n2 = (x >> 8) & 0xf;
+    let n3 = (x >> 12) & 0xf;
+    let n4 = (x >> 16) & 0xf;
+    let n5 = (x >> 20) & 0xf;
+
+    SPREAD[n0 as usize]
+        | (SPREAD[n1 as usize] << 20)
+        | (SPREAD[n2 as usize] << 40)
+        | (SPREAD[n3 as usize] << 60)
+        | (SPREAD[n4 as usize] << 80)
+        | (SPREAD[n5 as usize] << 100)
+        | ((x >> 24) & 1) << 120
+}
+
+/// Inverse of [`part_1by4`]: gathers every fifth bit back into the low 25 bits.
+#[inline]
+const fn compact_1by4(code: u128) -> u128 {
+    (code & 1)
+        | (((code >> 5) & 1) << 1)
+        | (((code >> 10) & 1) << 2)
+        | (((code >> 15) & 1) << 3)
+        | (((code >> 20) & 1) << 4)
+        | (((code >> 25) & 1) << 5)
+        | (((code >> 30) & 1) << 6)
+        | (((code >> 35) & 1) << 7)
+        | (((code >> 40) & 1) << 8)
+        | (((code >> 45) & 1) << 9)
+        | (((code >> 50) & 1) << 10)
+        | (((code >> 55) & 1) << 11)
+        | (((code >> 60) & 1) << 12)
+        | (((code >> 65) & 1) << 13)
+        | (((code >> 70) & 1) << 14)
+        | (((code >> 75) & 1) << 15)
+        | (((code >> 80) & 1) << 16)
+        | (((code >> 85) & 1) << 17)
+        | (((code >> 90) & 1) << 18)
+        | (((code >> 95) & 1) << 19)
+        | (((code >> 100) & 1) << 20)
+        | (((code >> 105) & 1) << 21)
+        | (((code >> 110) & 1) << 22)
+        | (((code >> 115) & 1) << 23)
+        | (((code >> 120) & 1) << 24)
+}
+
+impl Morton<5> for Dim<5> {
+    const CHILDREN: usize = 32;
+    const BITS: u32 = 25;
+    type Stack = [u32; 800];
+    type Word = u128;
+
+    fn empty_stack() -> Self::Stack {
+        [0u32; 800]
+    }
+
+    fn encode([c0, c1, c2, c3, c4]: [u32; 5]) -> Self::Word {
+        part_1by4(c0 as u128)
+            | (part_1by4(c1 as u128) << 1)
+            | (part_1by4(c2 as u128) << 2)
+            | (part_1by4(c3 as u128) << 3)
+            | (part_1by4(c4 as u128) << 4)
+    }
+
+    fn decode(code: Self::Word) -> [u32; 5] {
+        [
+            compact_1by4(code) as u32,
+            compact_1by4(code >> 1) as u32,
+            compact_1by4(code >> 2) as u32,
+            compact_1by4(code >> 3) as u32,
+            compact_1by4(code >> 4) as u32,
+        ]
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use proptest::prop_assert_eq;
+    use rand::{Rng, SeedableRng, rngs::StdRng};
+
+    use super::super::{Dim, Morton};
+
+    #[test]
+    fn encode_decode_roundtrips_5d() {
+        let mut rng = StdRng::seed_from_u64(0xabcd_ef01);
+        let mask = (1u32 << 25) - 1;
+        for _ in 0..10_000 {
+            let a = rng.random::<u32>() & mask;
+            let b = rng.random::<u32>() & mask;
+            let c = rng.random::<u32>() & mask;
+            let d = rng.random::<u32>() & mask;
+            let e = rng.random::<u32>() & mask;
+            let code = Dim::<5>::encode([a, b, c, d, e]);
+            assert_eq!(Dim::<5>::decode(code), [a, b, c, d, e]);
+        }
+    }
+
+    #[test]
+    fn encode_matches_known_z_order_5d() {
+        assert_eq!(Dim::<5>::encode([0, 0, 0, 0, 0]), 0);
+        assert_eq!(Dim::<5>::encode([1, 0, 0, 0, 0]), 1);
+        assert_eq!(Dim::<5>::encode([0, 1, 0, 0, 0]), 2);
+        assert_eq!(Dim::<5>::encode([0, 0, 1, 0, 0]), 4);
+        assert_eq!(Dim::<5>::encode([0, 0, 0, 1, 0]), 8);
+        assert_eq!(Dim::<5>::encode([0, 0, 0, 0, 1]), 16);
+        assert_eq!(Dim::<5>::encode([1, 1, 1, 1, 1]), 31);
+    }
+
+    proptest::proptest! {
+        #[test]
+        fn proptest_roundtrip_5d(a in 0u32..1 << 25, b in 0u32..1 << 25, c in 0u32..1 << 25, d in 0u32..1 << 25, e in 0u32..1 << 25) {
+            let code = Dim::<5>::encode([a, b, c, d, e]);
+            prop_assert_eq!(Dim::<5>::decode(code), [a, b, c, d, e]);
+        }
+    }
+}


### PR DESCRIPTION
Extends the Barnes-Hut path to embedding dimensionality `D = 5` (in addition to 2, 3, and 4). The Morton codec uses 25 bits per axis with a `u128` Z-order code, so points closer than `1 / 33554432` of the bounding-box width on any axis collapse into the same leaf cell.

The bit spreader uses a small lookup table because the standard binary-doubling algorithm only works when the inter-bit gap is a power of two, `D=5` needs a gap of four.