### PR TITLE
Add 6D Barnes-Hut support with 21-bit Morton codec

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 ## 0.7.11
 
-Add 5D support for the Barnes-Hut path: `barnes_hut` and `barnes_hut_with_neighbors` now accept an embedding dimensionality `D` of 5 (in addition to 2, 3, and 4). The Morton codec uses 25 bits per axis at `D = 5`, with a `u128` Z-order code (125 bits used), so points closer than `1 / 33554432` of the bounding-box width on any axis collapse into the same leaf cell.
+Add 5D and 6D support for the Barnes-Hut path: `barnes_hut` and `barnes_hut_with_neighbors` now accept an embedding dimensionality `D` of 5 or 6 (in addition to 2, 3, and 4). The Morton codec uses 25 bits per axis at `D = 5` (125 bits, `u128` code) and 21 bits per axis at `D = 6` (126 bits, `u128` code).
 
 ## 0.7.10
 Add 4D support for the Barnes-Hut path: `barnes_hut` and `barnes_hut_with_neighbors` now accept an embedding dimensionality `D` of 4 (in addition to 2 and 3). The Morton codec uses 16 bits per axis at `D = 4`, so points closer than `1 / 65536` of the bounding-box width on any axis collapse into the same leaf cell.

--- a/README.md
+++ b/README.md
@@ -65,7 +65,7 @@ bhtsne::tSNE::<f32, &[f32], 2>::new(&samples)
 
 In the example euclidean distance is used, but any other distance metric on data types of choice, such as strings, can be defined and plugged in.
 
-The tree-accelerated `barnes_hut` and `barnes_hut_with_neighbors` support an embedding dimensionality `D` of 2, 3, 4, or 5, the dimensionalities a Z-order code covers with ample precision (32, 21, 16, and 25 bits per axis, respectively). The exact `exact` path stays general for any `D`.
+The tree-accelerated `barnes_hut` and `barnes_hut_with_neighbors` support an embedding dimensionality `D` of 2, 3, 4, 5, or 6, the dimensionalities a Z-order code covers with ample precision (32, 21, 16, 25, and 21 bits per axis, respectively). The exact `exact` path stays general for any `D`.
 
 ## FIt-SNE
 

--- a/src/test.rs
+++ b/src/test.rs
@@ -1959,3 +1959,30 @@ fn barnes_hut_runs_in_five_dimensions() {
     assert_eq!(embedding.len(), N * 5);
     assert!(embedding.iter().all(|v| v.is_finite()));
 }
+
+/// Smoke test for the 6D Barnes-Hut path: the embedding stays finite and correctly sized
+/// after a short fit.
+#[test]
+fn barnes_hut_runs_in_six_dimensions() {
+    const N: usize = 200;
+    const DIN: usize = 7;
+
+    let data = lcg_samples(N, DIN, 45);
+    let samples: Vec<&[f32]> = data.chunks(DIN).collect();
+    let mut tsne: tSNE<f32, &[f32], 6> = tSNE::new(&samples);
+    tsne.perplexity(PERPLEXITY)
+        .epochs(50)
+        .barnes_hut(THETA, |a, b| euclidean(a, b));
+    let embedding = tsne.embedding();
+    assert_eq!(embedding.len(), N * 6);
+    assert!(embedding.iter().all(|v| v.is_finite()));
+}
+
+/// Verify the 6D Morton codec and arena path compile and function correctly.
+#[test]
+fn arena_builds_6d() {
+    const N: usize = 500;
+    let data = lcg_samples(N, 6, 46);
+    let arena = tsne::arena::Arena::<f32, u128, 6>::new(&data, N);
+    assert_eq!(arena.root_count(), N);
+}

--- a/src/tsne/morton.rs
+++ b/src/tsne/morton.rs
@@ -2,15 +2,17 @@
 //!
 //! The arena encodes each embedding point as a single Morton code: the per-axis quantized
 //! coordinates are bit-interleaved so that sorting the codes lays the points out in Z-order, where
-//! points sharing a code prefix share a tree cell. `D in {2, 3, 4, 5}` are supported, with 32 bits
-//! per axis at `D = 2` (lossless for `f32`), 21 bits at `D = 3`, 16 bits at `D = 4`, and 25 bits
-//! at `D = 5`. The [`Morton`] trait is implemented for those four dimensions, so the bound
-//! `Dim<D>: Morton<D>` is what restricts the Barnes-Hut tree path at compile time.
+//! points sharing a code prefix share a tree cell. `D in {2, 3, 4, 5, 6}` are supported, with 32
+//! bits per axis at `D = 2` (lossless for `f32`), 21 bits at `D = 3`, 16 bits at `D = 4`, 25
+//! bits at `D = 5`, and 21 bits at `D = 6`. The [`Morton`] trait is implemented for those five
+//! dimensions, so the bound `Dim<D>: Morton<D>` is what restricts the Barnes-Hut tree path at
+//! compile time.
 
 mod d2;
 mod d3;
 mod d4;
 mod d5;
+mod d6;
 
 use num_traits::Float;
 
@@ -62,7 +64,7 @@ impl MortonWord for u128 {
     }
 }
 
-/// Per-dimension Z-order codec, implemented for [`Dim<2>`], [`Dim<3>`], [`Dim<4>`], and [`Dim<5>`].
+/// Per-dimension Z-order codec, implemented for [`Dim<2>`], [`Dim<3>`], [`Dim<4>`], [`Dim<5>`], and [`Dim<6>`].
 pub trait Morton<const D: usize> {
     /// Number of children a fully occupied internal cell can have, `2^D`.
     const CHILDREN: usize;

--- a/src/tsne/morton/d6.rs
+++ b/src/tsne/morton/d6.rs
@@ -1,0 +1,169 @@
+//! 6D Morton codec: 21 bits per axis.
+//!
+//! Uses a lookup table for the bit spreader since the final gap of 5 (six positions apart) does
+//! not decompose as powers of two, which breaks the standard binary-doubling shift-and-mask
+//! algorithm used for D in {2, 3, 4}.
+//!
+//! The 21 bits are split into four 5-bit chunks (20 bits) plus one remaining bit. Each chunk
+//! spreads via a small lookup table and the results concatenate at 30-bit offsets. The final
+//! interleaved code uses 126 bits (21 * 6), fitting in `u128`.
+
+use super::{Dim, Morton};
+
+/// Spreads the low 21 bits of `x` so each lands six positions apart (five gaps), the 6D Morton
+/// building block.
+///
+/// The low 20 bits are split into four 5-bit chunks. Each chunk spreads via a lookup table
+/// and the four results concatenate at 30-bit offsets. Bit 20 is placed directly at position
+/// 120.
+#[inline]
+const fn part_1by5(x: u128) -> u128 {
+    // Spread table for a single 5-bit chunk: bit i at position 6*i.
+    const SPREAD: [u128; 32] = [
+        0x0000_0000_0000_0000,
+        0x0000_0000_0000_0001,
+        0x0000_0000_0000_0040,
+        0x0000_0000_0000_0041,
+        0x0000_0000_0000_1000,
+        0x0000_0000_0000_1001,
+        0x0000_0000_0000_1040,
+        0x0000_0000_0000_1041,
+        0x0000_0000_0004_0000,
+        0x0000_0000_0004_0001,
+        0x0000_0000_0004_0040,
+        0x0000_0000_0004_0041,
+        0x0000_0000_0004_1000,
+        0x0000_0000_0004_1001,
+        0x0000_0000_0004_1040,
+        0x0000_0000_0004_1041,
+        0x0000_0000_0100_0000,
+        0x0000_0000_0100_0001,
+        0x0000_0000_0100_0040,
+        0x0000_0000_0100_0041,
+        0x0000_0000_0100_1000,
+        0x0000_0000_0100_1001,
+        0x0000_0000_0100_1040,
+        0x0000_0000_0100_1041,
+        0x0000_0000_0104_0000,
+        0x0000_0000_0104_0001,
+        0x0000_0000_0104_0040,
+        0x0000_0000_0104_0041,
+        0x0000_0000_0104_1000,
+        0x0000_0000_0104_1001,
+        0x0000_0000_0104_1040,
+        0x0000_0000_0104_1041,
+    ];
+
+    let x = x & 0x00_1f_ff_ff;
+    let c0 = x & 0x1f;
+    let c1 = (x >> 5) & 0x1f;
+    let c2 = (x >> 10) & 0x1f;
+    let c3 = (x >> 15) & 0x1f;
+
+    SPREAD[c0 as usize]
+        | (SPREAD[c1 as usize] << 30)
+        | (SPREAD[c2 as usize] << 60)
+        | (SPREAD[c3 as usize] << 90)
+        | ((x >> 20) & 1) << 120
+}
+
+/// Inverse of [`part_1by5`]: gathers every sixth bit back into the low 21 bits.
+#[inline]
+const fn compact_1by5(code: u128) -> u128 {
+    (code & 1)
+        | (((code >> 6) & 1) << 1)
+        | (((code >> 12) & 1) << 2)
+        | (((code >> 18) & 1) << 3)
+        | (((code >> 24) & 1) << 4)
+        | (((code >> 30) & 1) << 5)
+        | (((code >> 36) & 1) << 6)
+        | (((code >> 42) & 1) << 7)
+        | (((code >> 48) & 1) << 8)
+        | (((code >> 54) & 1) << 9)
+        | (((code >> 60) & 1) << 10)
+        | (((code >> 66) & 1) << 11)
+        | (((code >> 72) & 1) << 12)
+        | (((code >> 78) & 1) << 13)
+        | (((code >> 84) & 1) << 14)
+        | (((code >> 90) & 1) << 15)
+        | (((code >> 96) & 1) << 16)
+        | (((code >> 102) & 1) << 17)
+        | (((code >> 108) & 1) << 18)
+        | (((code >> 114) & 1) << 19)
+        | (((code >> 120) & 1) << 20)
+}
+
+impl Morton<6> for Dim<6> {
+    const CHILDREN: usize = 64;
+    const BITS: u32 = 21;
+    type Stack = [u32; 1344];
+    type Word = u128;
+
+    fn empty_stack() -> Self::Stack {
+        [0u32; 1344]
+    }
+
+    fn encode([c0, c1, c2, c3, c4, c5]: [u32; 6]) -> Self::Word {
+        part_1by5(c0 as u128)
+            | (part_1by5(c1 as u128) << 1)
+            | (part_1by5(c2 as u128) << 2)
+            | (part_1by5(c3 as u128) << 3)
+            | (part_1by5(c4 as u128) << 4)
+            | (part_1by5(c5 as u128) << 5)
+    }
+
+    fn decode(code: Self::Word) -> [u32; 6] {
+        [
+            compact_1by5(code) as u32,
+            compact_1by5(code >> 1) as u32,
+            compact_1by5(code >> 2) as u32,
+            compact_1by5(code >> 3) as u32,
+            compact_1by5(code >> 4) as u32,
+            compact_1by5(code >> 5) as u32,
+        ]
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use proptest::prop_assert_eq;
+    use rand::{Rng, SeedableRng, rngs::StdRng};
+
+    use super::super::{Dim, Morton};
+
+    #[test]
+    fn encode_decode_roundtrips_6d() {
+        let mut rng = StdRng::seed_from_u64(0xabcd_ef02);
+        let mask = (1u32 << 21) - 1;
+        for _ in 0..10_000 {
+            let a = rng.random::<u32>() & mask;
+            let b = rng.random::<u32>() & mask;
+            let c = rng.random::<u32>() & mask;
+            let d = rng.random::<u32>() & mask;
+            let e = rng.random::<u32>() & mask;
+            let f = rng.random::<u32>() & mask;
+            let code = Dim::<6>::encode([a, b, c, d, e, f]);
+            assert_eq!(Dim::<6>::decode(code), [a, b, c, d, e, f]);
+        }
+    }
+
+    #[test]
+    fn encode_matches_known_z_order_6d() {
+        assert_eq!(Dim::<6>::encode([0, 0, 0, 0, 0, 0]), 0);
+        assert_eq!(Dim::<6>::encode([1, 0, 0, 0, 0, 0]), 1);
+        assert_eq!(Dim::<6>::encode([0, 1, 0, 0, 0, 0]), 2);
+        assert_eq!(Dim::<6>::encode([0, 0, 1, 0, 0, 0]), 4);
+        assert_eq!(Dim::<6>::encode([0, 0, 0, 1, 0, 0]), 8);
+        assert_eq!(Dim::<6>::encode([0, 0, 0, 0, 1, 0]), 16);
+        assert_eq!(Dim::<6>::encode([0, 0, 0, 0, 0, 1]), 32);
+        assert_eq!(Dim::<6>::encode([1, 1, 1, 1, 1, 1]), 63);
+    }
+
+    proptest::proptest! {
+        #[test]
+        fn proptest_roundtrip_6d(a in 0u32..1 << 21, b in 0u32..1 << 21, c in 0u32..1 << 21, d in 0u32..1 << 21, e in 0u32..1 << 21, f in 0u32..1 << 21) {
+            let code = Dim::<6>::encode([a, b, c, d, e, f]);
+            prop_assert_eq!(Dim::<6>::decode(code), [a, b, c, d, e, f]);
+        }
+    }
+}


### PR DESCRIPTION
Add `Morton<6>` for `Dim<6>`: 21 bits per axis, `u128` Z-order code (126 bits), 64 children per cell. The spreader uses a 32-entry LUT for 5-bit chunks (bit `i` at position `6*i`), four chunks concatenated at 30-bit offsets, and bit 20 placed directly at position 120.

This is built on top of PR #48 so you should merge that one first, and this hopefully will rebase cleanly.