### PR TITLE
Add 7D Barnes-Hut support with 18-bit Morton codec

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 ## 0.7.11
 
-Add 5D and 6D support for the Barnes-Hut path: `barnes_hut` and `barnes_hut_with_neighbors` now accept an embedding dimensionality `D` of 5 or 6 (in addition to 2, 3, and 4). The Morton codec uses 25 bits per axis at `D = 5` (125 bits, `u128` code) and 21 bits per axis at `D = 6` (126 bits, `u128` code).
+Add 5D, 6D, and 7D support for the Barnes-Hut path: `barnes_hut` and `barnes_hut_with_neighbors` now accept an embedding dimensionality `D` of 5, 6, or 7 (in addition to 2, 3, and 4). The Morton codec uses 25 bits per axis at `D = 5` (125 bits, `u128` code), 21 bits per axis at `D = 6` (126 bits, `u128` code), and 18 bits per axis at `D = 7` (126 bits, `u128` code).
 
 ## 0.7.10
 Add 4D support for the Barnes-Hut path: `barnes_hut` and `barnes_hut_with_neighbors` now accept an embedding dimensionality `D` of 4 (in addition to 2 and 3). The Morton codec uses 16 bits per axis at `D = 4`, so points closer than `1 / 65536` of the bounding-box width on any axis collapse into the same leaf cell.

--- a/README.md
+++ b/README.md
@@ -65,7 +65,7 @@ bhtsne::tSNE::<f32, &[f32], 2>::new(&samples)
 
 In the example euclidean distance is used, but any other distance metric on data types of choice, such as strings, can be defined and plugged in.
 
-The tree-accelerated `barnes_hut` and `barnes_hut_with_neighbors` support an embedding dimensionality `D` of 2, 3, 4, 5, or 6, the dimensionalities a Z-order code covers with ample precision (32, 21, 16, 25, and 21 bits per axis, respectively). The exact `exact` path stays general for any `D`.
+The tree-accelerated `barnes_hut` and `barnes_hut_with_neighbors` support an embedding dimensionality `D` of 2, 3, 4, 5, 6, or 7, the dimensionalities a Z-order code covers with ample precision (32, 21, 16, 25, 21, and 18 bits per axis, respectively). The exact `exact` path stays general for any `D`.
 
 ## FIt-SNE
 

--- a/src/test.rs
+++ b/src/test.rs
@@ -1986,3 +1986,29 @@ fn arena_builds_6d() {
     let arena = tsne::arena::Arena::<f32, u128, 6>::new(&data, N);
     assert_eq!(arena.root_count(), N);
 }
+
+/// Verify the 7D Morton codec and arena path compile and function correctly.
+#[test]
+fn barnes_hut_runs_in_seven_dimensions() {
+    const N: usize = 200;
+    const DIN: usize = 8;
+
+    let data = lcg_samples(N, DIN, 46);
+    let samples: Vec<&[f32]> = data.chunks(DIN).collect();
+    let mut tsne: tSNE<f32, &[f32], 7> = tSNE::new(&samples);
+    tsne.perplexity(PERPLEXITY)
+        .epochs(50)
+        .barnes_hut(THETA, |a, b| euclidean(a, b));
+    let embedding = tsne.embedding();
+    assert_eq!(embedding.len(), N * 7);
+    assert!(embedding.iter().all(|v| v.is_finite()));
+}
+
+/// Verify the 7D Morton codec and arena path compile and function correctly.
+#[test]
+fn arena_builds_7d() {
+    const N: usize = 500;
+    let data = lcg_samples(N, 7, 47);
+    let arena = tsne::arena::Arena::<f32, u128, 7>::new(&data, N);
+    assert_eq!(arena.root_count(), N);
+}

--- a/src/tsne/morton.rs
+++ b/src/tsne/morton.rs
@@ -2,9 +2,9 @@
 //!
 //! The arena encodes each embedding point as a single Morton code: the per-axis quantized
 //! coordinates are bit-interleaved so that sorting the codes lays the points out in Z-order, where
-//! points sharing a code prefix share a tree cell. `D in {2, 3, 4, 5, 6}` are supported, with 32
+//! points sharing a code prefix share a tree cell. `D in {2, 3, 4, 5, 6, 7}` are supported, with 32
 //! bits per axis at `D = 2` (lossless for `f32`), 21 bits at `D = 3`, 16 bits at `D = 4`, 25
-//! bits at `D = 5`, and 21 bits at `D = 6`. The [`Morton`] trait is implemented for those five
+//! bits at `D = 5`, 21 bits at `D = 6`, and 18 bits at `D = 7`. The [`Morton`] trait is implemented for those six
 //! dimensions, so the bound `Dim<D>: Morton<D>` is what restricts the Barnes-Hut tree path at
 //! compile time.
 
@@ -13,6 +13,7 @@ mod d3;
 mod d4;
 mod d5;
 mod d6;
+mod d7;
 
 use num_traits::Float;
 
@@ -64,7 +65,7 @@ impl MortonWord for u128 {
     }
 }
 
-/// Per-dimension Z-order codec, implemented for [`Dim<2>`], [`Dim<3>`], [`Dim<4>`], [`Dim<5>`], and [`Dim<6>`].
+/// Per-dimension Z-order codec, implemented for [`Dim<2>`], [`Dim<3>`], [`Dim<4>`], [`Dim<5>`], [`Dim<6>`], and [`Dim<7>`].
 pub trait Morton<const D: usize> {
     /// Number of children a fully occupied internal cell can have, `2^D`.
     const CHILDREN: usize;

--- a/src/tsne/morton/d7.rs
+++ b/src/tsne/morton/d7.rs
@@ -1,0 +1,168 @@
+//! 7D Morton codec: 18 bits per axis.
+//!
+//! Uses a lookup table for the bit spreader. The 18 bits split into three 5-bit chunks (15 bits)
+//! plus three remaining bits. Each chunk spreads via a 32-entry lookup table and the results
+//! concatenate at 35-bit offsets. The final interleaved code uses 126 bits (18 * 7), fitting in
+//! `u128`.
+
+use super::{Dim, Morton};
+
+/// Spreads the low 18 bits of `x` so each lands seven positions apart (six gaps), the 7D Morton
+/// building block.
+///
+/// The low 15 bits are split into three 5-bit chunks. Each chunk spreads via a lookup table
+/// and the three results concatenate at 35-bit offsets. The remaining three bits are placed
+/// directly at positions 105, 112, and 119.
+#[inline]
+const fn part_1by6(x: u128) -> u128 {
+    // Spread table for a single 5-bit chunk: bit i at position 7*i.
+    const SPREAD: [u128; 32] = [
+        0x0000_0000_0000_0000,
+        0x0000_0000_0000_0001,
+        0x0000_0000_0000_0080,
+        0x0000_0000_0000_0081,
+        0x0000_0000_0000_4000,
+        0x0000_0000_0000_4001,
+        0x0000_0000_0000_4080,
+        0x0000_0000_0000_4081,
+        0x0000_0000_0020_0000,
+        0x0000_0000_0020_0001,
+        0x0000_0000_0020_0080,
+        0x0000_0000_0020_0081,
+        0x0000_0000_0020_4000,
+        0x0000_0000_0020_4001,
+        0x0000_0000_0020_4080,
+        0x0000_0000_0020_4081,
+        0x0000_0000_1000_0000,
+        0x0000_0000_1000_0001,
+        0x0000_0000_1000_0080,
+        0x0000_0000_1000_0081,
+        0x0000_0000_1000_4000,
+        0x0000_0000_1000_4001,
+        0x0000_0000_1000_4080,
+        0x0000_0000_1000_4081,
+        0x0000_0000_1020_0000,
+        0x0000_0000_1020_0001,
+        0x0000_0000_1020_0080,
+        0x0000_0000_1020_0081,
+        0x0000_0000_1020_4000,
+        0x0000_0000_1020_4001,
+        0x0000_0000_1020_4080,
+        0x0000_0000_1020_4081,
+    ];
+
+    let x = x & 0x0003_ffff;
+    let c0 = x & 0x1f;
+    let c1 = (x >> 5) & 0x1f;
+    let c2 = (x >> 10) & 0x1f;
+    let r = (x >> 15) & 0x7;
+
+    SPREAD[c0 as usize]
+        | (SPREAD[c1 as usize] << 35)
+        | (SPREAD[c2 as usize] << 70)
+        | ((r & 1) << 105)
+        | (((r >> 1) & 1) << 112)
+        | (((r >> 2) & 1) << 119)
+}
+
+/// Inverse of [`part_1by6`]: gathers every seventh bit back into the low 18 bits.
+#[inline]
+const fn compact_1by6(code: u128) -> u128 {
+    (code & 1)
+        | (((code >> 7) & 1) << 1)
+        | (((code >> 14) & 1) << 2)
+        | (((code >> 21) & 1) << 3)
+        | (((code >> 28) & 1) << 4)
+        | (((code >> 35) & 1) << 5)
+        | (((code >> 42) & 1) << 6)
+        | (((code >> 49) & 1) << 7)
+        | (((code >> 56) & 1) << 8)
+        | (((code >> 63) & 1) << 9)
+        | (((code >> 70) & 1) << 10)
+        | (((code >> 77) & 1) << 11)
+        | (((code >> 84) & 1) << 12)
+        | (((code >> 91) & 1) << 13)
+        | (((code >> 98) & 1) << 14)
+        | (((code >> 105) & 1) << 15)
+        | (((code >> 112) & 1) << 16)
+        | (((code >> 119) & 1) << 17)
+}
+
+impl Morton<7> for Dim<7> {
+    const CHILDREN: usize = 128;
+    const BITS: u32 = 18;
+    type Stack = [u32; 2304];
+    type Word = u128;
+
+    fn empty_stack() -> Self::Stack {
+        [0u32; 2304]
+    }
+
+    fn encode([c0, c1, c2, c3, c4, c5, c6]: [u32; 7]) -> Self::Word {
+        part_1by6(c0 as u128)
+            | (part_1by6(c1 as u128) << 1)
+            | (part_1by6(c2 as u128) << 2)
+            | (part_1by6(c3 as u128) << 3)
+            | (part_1by6(c4 as u128) << 4)
+            | (part_1by6(c5 as u128) << 5)
+            | (part_1by6(c6 as u128) << 6)
+    }
+
+    fn decode(code: Self::Word) -> [u32; 7] {
+        [
+            compact_1by6(code) as u32,
+            compact_1by6(code >> 1) as u32,
+            compact_1by6(code >> 2) as u32,
+            compact_1by6(code >> 3) as u32,
+            compact_1by6(code >> 4) as u32,
+            compact_1by6(code >> 5) as u32,
+            compact_1by6(code >> 6) as u32,
+        ]
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use proptest::prop_assert_eq;
+    use rand::{Rng, SeedableRng, rngs::StdRng};
+
+    use super::super::{Dim, Morton};
+
+    #[test]
+    fn encode_decode_roundtrips_7d() {
+        let mut rng = StdRng::seed_from_u64(0xabcd_ef03);
+        let mask = (1u32 << 18) - 1;
+        for _ in 0..10_000 {
+            let a = rng.random::<u32>() & mask;
+            let b = rng.random::<u32>() & mask;
+            let c = rng.random::<u32>() & mask;
+            let d = rng.random::<u32>() & mask;
+            let e = rng.random::<u32>() & mask;
+            let f = rng.random::<u32>() & mask;
+            let g = rng.random::<u32>() & mask;
+            let code = Dim::<7>::encode([a, b, c, d, e, f, g]);
+            assert_eq!(Dim::<7>::decode(code), [a, b, c, d, e, f, g]);
+        }
+    }
+
+    #[test]
+    fn encode_matches_known_z_order_7d() {
+        assert_eq!(Dim::<7>::encode([0, 0, 0, 0, 0, 0, 0]), 0);
+        assert_eq!(Dim::<7>::encode([1, 0, 0, 0, 0, 0, 0]), 1);
+        assert_eq!(Dim::<7>::encode([0, 1, 0, 0, 0, 0, 0]), 2);
+        assert_eq!(Dim::<7>::encode([0, 0, 1, 0, 0, 0, 0]), 4);
+        assert_eq!(Dim::<7>::encode([0, 0, 0, 1, 0, 0, 0]), 8);
+        assert_eq!(Dim::<7>::encode([0, 0, 0, 0, 1, 0, 0]), 16);
+        assert_eq!(Dim::<7>::encode([0, 0, 0, 0, 0, 1, 0]), 32);
+        assert_eq!(Dim::<7>::encode([0, 0, 0, 0, 0, 0, 1]), 64);
+        assert_eq!(Dim::<7>::encode([1, 1, 1, 1, 1, 1, 1]), 127);
+    }
+
+    proptest::proptest! {
+        #[test]
+        fn proptest_roundtrip_7d(a in 0u32..1 << 18, b in 0u32..1 << 18, c in 0u32..1 << 18, d in 0u32..1 << 18, e in 0u32..1 << 18, f in 0u32..1 << 18, g in 0u32..1 << 18) {
+            let code = Dim::<7>::encode([a, b, c, d, e, f, g]);
+            prop_assert_eq!(Dim::<7>::decode(code), [a, b, c, d, e, f, g]);
+        }
+    }
+}


### PR DESCRIPTION
Add `Morton<7>` for `Dim<7>` with `Word = u128` and 18 bits per axis (126 bits total). The spreader uses the same chunk-based lookup table pattern as D=5 and D=6: three 5-bit chunks spread via a 32-entry LUT at 35-bit offsets, with the remaining three bits placed directly at positions 105, 112, and 119. Binary doubling would overflow `u128` at intermediate shifts so the LUT approach is necessary.

This PR is built on top of the D=5 and D=6 PRs and should be merged only after those are landed.