### PR TITLE
Make `barnes-hut-tree` `no_std` + `alloc` with optional `rayon`

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -60,6 +60,23 @@ jobs:
       - name: Clippy on wasm32-unknown-unknown
         run: cargo clippy --target wasm32-unknown-unknown --features wasm_js -- -D warnings
 
+  no_std:
+    name: no_std and sequential barnes-hut-tree
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: dtolnay/rust-toolchain@stable
+        with:
+          targets: thumbv7em-none-eabi
+          components: clippy
+      - uses: Swatinem/rust-cache@v2
+      - name: Build barnes-hut-tree no_std + alloc on bare metal
+        run: cargo build -p barnes-hut-tree --no-default-features --target thumbv7em-none-eabi
+      - name: Clippy barnes-hut-tree no_std + alloc on bare metal
+        run: cargo clippy -p barnes-hut-tree --no-default-features --target thumbv7em-none-eabi -- -D warnings
+      - name: Test barnes-hut-tree sequential fallback
+        run: cargo test -p barnes-hut-tree --no-default-features --features std
+
   audit:
     name: Security audit
     runs-on: ubuntu-latest

--- a/barnes-hut-tree/CHANGELOG.md
+++ b/barnes-hut-tree/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## 0.1.1
+
+`no_std` + `alloc` support. `rayon` is now the optional, default-on `parallel` feature, with a sequential fallback when it is off (identical results up to floating-point summation order). The float bound is relaxed from `num_traits::Float` to `num_traits::float::FloatCore`, which the tree's arithmetic fits entirely, so dropping the default `std` feature builds the crate on bare metal with no math backend and `--no-default-features` alone compiles.
+
 ## 0.1.0
 
 Initial extraction from the `bhtsne` crate into a reusable Barnes-Hut primitive.

--- a/barnes-hut-tree/Cargo.toml
+++ b/barnes-hut-tree/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "barnes-hut-tree"
-version = "0.1.0"
+version = "0.1.1"
 edition = "2024"
 license = "MIT"
 description = "Morton-code Barnes-Hut tree for spatial force approximation."
@@ -12,8 +12,14 @@ repository = "https://github.com/frjnn/bhtsne"
 unsafe_code = "forbid"
 
 [dependencies]
-num-traits = "0.2"
-rayon = "1"
+num-traits = { version = "0.2", default-features = false }
+rayon = { version = "1", optional = true }
+
+[features]
+default = ["std", "parallel"]
+std = ["num-traits/std"]
+# rayon needs threads, so parallel implies std.
+parallel = ["dep:rayon", "std"]
 
 [dev-dependencies]
 proptest = "1"

--- a/barnes-hut-tree/README.md
+++ b/barnes-hut-tree/README.md
@@ -54,9 +54,14 @@ tree.compute_non_edge_forces(
 );
 ```
 
-## Parallelism
+## Parallelism and `no_std`
 
-Built on [rayon](https://github.com/rayon-rs/rayon), the arena build and force reductions run on whatever thread pool the caller runs in. See [rayon's FAQ](https://github.com/rayon-rs/rayon/blob/master/FAQ.md) for the physical versus logical cores discussion.
+The default `parallel` feature runs the arena build and force reductions on [rayon](https://github.com/rayon-rs/rayon). Turning it off swaps in a sequential fallback with the same results up to floating-point summation order. Dropping the default `std` feature makes the crate `no_std` + `alloc` for bare metal. The tree only needs `num_traits::float::FloatCore`, so no math backend is required:
+
+```toml
+[dependencies]
+barnes-hut-tree = { version = "0.1", default-features = false }
+```
 
 ## License
 

--- a/barnes-hut-tree/src/arena.rs
+++ b/barnes-hut-tree/src/arena.rs
@@ -8,10 +8,13 @@
 //! mass, mass, level), never raw coordinates. Morton quantization is total, so every point maps
 //! to exactly one cell, which the build asserts (leaf counts sum to `n`).
 
-use std::{array, ops::AddAssign};
+use core::{array, ops::AddAssign};
 
-use num_traits::Float;
+use alloc::vec::Vec;
 
+use num_traits::float::FloatCore;
+
+#[cfg(feature = "parallel")]
 use rayon::prelude::*;
 
 use crate::{
@@ -21,6 +24,7 @@ use crate::{
 
 /// Minimum sample count before parallel rayon iterations use `with_min_len` to avoid
 /// overhead on small workloads.
+#[cfg(feature = "parallel")]
 const ARENA_MIN_CHUNK: usize = 4096;
 
 /// `first_child` value marking a leaf, a node with no children in the arena.
@@ -71,41 +75,45 @@ where
     level_half_width_sq: Vec<T>,
 }
 
-/// Per-axis bounding box of the embedding, reduced in parallel.
+/// Per-axis bounding box of the embedding.
 fn bounding_box<T, const D: usize>(y_chunks: &[[T; D]]) -> ([T; D], [T; D])
 where
-    T: Float + Send + Sync,
+    T: FloatCore + Send + Sync,
 {
-    y_chunks
-        .par_iter()
-        .with_min_len(ARENA_MIN_CHUNK)
-        .fold(
-            || ([T::max_value(); D], [-T::max_value(); D]),
-            |(mut min, mut max), point| {
-                for axis in 0..D {
-                    min[axis] = min[axis].min(point[axis]);
-                    max[axis] = max[axis].max(point[axis]);
-                }
+    let identity = || ([T::max_value(); D], [-T::max_value(); D]);
+    let widen = |(mut min, mut max): ([T; D], [T; D]), point: &[T; D]| {
+        for axis in 0..D {
+            min[axis] = min[axis].min(point[axis]);
+            max[axis] = max[axis].max(point[axis]);
+        }
 
-                (min, max)
-            },
-        )
-        .reduce(
-            || ([T::max_value(); D], [-T::max_value(); D]),
-            |(mut min_a, mut max_a), (min_b, max_b)| {
+        (min, max)
+    };
+
+    #[cfg(feature = "parallel")]
+    {
+        y_chunks
+            .par_iter()
+            .with_min_len(ARENA_MIN_CHUNK)
+            .fold(identity, widen)
+            .reduce(identity, |(mut min_a, mut max_a), (min_b, max_b)| {
                 for axis in 0..D {
                     min_a[axis] = min_a[axis].min(min_b[axis]);
                     max_a[axis] = max_a[axis].max(max_b[axis]);
                 }
 
                 (min_a, max_a)
-            },
-        )
+            })
+    }
+    #[cfg(not(feature = "parallel"))]
+    {
+        y_chunks.iter().fold(identity(), widen)
+    }
 }
 
 impl<T, W, const D: usize> BarnesHutTree<T, W, D>
 where
-    T: Float + Send + Sync + AddAssign,
+    T: FloatCore + Send + Sync + AddAssign,
     W: MortonWord,
 {
     /// Creates an empty arena. The epoch loop holds one of these and rebuilds it each epoch so the
@@ -238,20 +246,29 @@ where
 
         // 2-4. Quantize, encode, and sort a (code, index) permutation into Z-order. `sorted` is
         // refilled from the cleared buffer, reusing its capacity across epochs.
-        self.sorted.par_extend(
-            (0..n_samples)
-                .into_par_iter()
-                .with_min_len(ARENA_MIN_CHUNK)
-                .map(|i| {
-                    let point = &y_chunks[i];
-                    let code = <Dim<D> as Morton<D>>::encode(quantize::<T, D>(
-                        point, &min, &inv_scale, max_bucket,
-                    ));
+        let encode_at = |i: usize| {
+            let point = &y_chunks[i];
+            let code = <Dim<D> as Morton<D>>::encode(quantize::<T, D>(
+                point, &min, &inv_scale, max_bucket,
+            ));
 
-                    (code, i as u32)
-                }),
-        );
-        self.sorted.par_sort_unstable_by_key(|&(code, _)| code);
+            (code, i as u32)
+        };
+        #[cfg(feature = "parallel")]
+        {
+            self.sorted.par_extend(
+                (0..n_samples)
+                    .into_par_iter()
+                    .with_min_len(ARENA_MIN_CHUNK)
+                    .map(&encode_at),
+            );
+            self.sorted.par_sort_unstable_by_key(|&(code, _)| code);
+        }
+        #[cfg(not(feature = "parallel"))]
+        {
+            self.sorted.extend((0..n_samples).map(&encode_at));
+            self.sorted.sort_unstable_by_key(|&(code, _)| code);
+        }
 
         let sorted = &self.sorted;
         let nodes = &mut self.nodes;
@@ -321,34 +338,42 @@ where
             node += 1;
         }
 
-        // 6a. Leaf mass and mass-weighted center of mass, per leaf in parallel. Internal
-        // centers come from the bottom-up reduction below.
+        // 6a. Leaf mass and mass-weighted center of mass, per leaf. Each leaf writes only its
+        // own node. Internal centers come from the bottom-up reduction below.
         let mass_ref = &mass_of;
+        let aggregate_leaf = |(node, &(start, end)): (&mut Node<T, D>, &(u32, u32))| {
+            let mut center = [T::zero(); D];
+            let mut total = T::zero();
+            for slot in start..end {
+                let index = sorted[slot as usize].1 as usize;
+                let weight = mass_ref(index);
+                total += weight;
+                let point = &y_chunks[index];
+                center
+                    .iter_mut()
+                    .zip(point.iter())
+                    .for_each(|(ci, pi)| *ci += weight * *pi);
+            }
+            let inverse = total.recip();
+            center
+                .iter_mut()
+                .for_each(|value| *value = *value * inverse);
+            node.mass = total;
+            node.center_of_mass = center;
+        };
+        #[cfg(feature = "parallel")]
         nodes
             .par_iter_mut()
             .zip(ranges.par_iter())
             .with_min_len(ARENA_MIN_CHUNK)
             .filter(|(node, _)| node.first_child == SENTINEL)
-            .for_each(|(node, &(start, end))| {
-                let mut center = [T::zero(); D];
-                let mut total = T::zero();
-                for slot in start..end {
-                    let index = sorted[slot as usize].1 as usize;
-                    let weight = mass_ref(index);
-                    total += weight;
-                    let point = &y_chunks[index];
-                    center
-                        .iter_mut()
-                        .zip(point.iter())
-                        .for_each(|(ci, pi)| *ci += weight * *pi);
-                }
-                let inverse = total.recip();
-                center
-                    .iter_mut()
-                    .for_each(|value| *value = *value * inverse);
-                node.mass = total;
-                node.center_of_mass = center;
-            });
+            .for_each(aggregate_leaf);
+        #[cfg(not(feature = "parallel"))]
+        nodes
+            .iter_mut()
+            .zip(ranges.iter())
+            .filter(|(node, _)| node.first_child == SENTINEL)
+            .for_each(aggregate_leaf);
 
         // 6b. Internal mass and mass-weighted center of mass, bottom up. Children always sit
         // at a higher arena index than their parent.
@@ -522,9 +547,9 @@ where
         }
     }
 
-    /// Parallel driver over [`BarnesHutTree::accumulate_forces`]: force on every
-    /// `D`-component row of `queries` into the matching row of `out`. Each row runs on its
-    /// own rayon task with a stack-allocated traversal stack. `out` is overwritten per row.
+    /// Driver over [`BarnesHutTree::accumulate_forces`]: force on every `D`-component row of
+    /// `queries` into the matching row of `out`, overwritten per row. Rows run in parallel under
+    /// the `parallel` feature, otherwise in sequence reusing one traversal stack.
     ///
     /// # Panics
     ///
@@ -541,14 +566,25 @@ where
         );
         assert_eq!(queries.len(), out.len(), "out must match queries in length");
 
+        let compute_row = |stack: &mut [u32], (row, query): (&mut [T], &[T])| {
+            let mut force = [T::zero(); D];
+            self.accumulate_forces(query, theta, kernel, &mut force, stack);
+            row.copy_from_slice(&force);
+        };
+        #[cfg(feature = "parallel")]
         out.par_chunks_mut(D)
             .zip(queries.par_chunks(D))
             .with_min_len(ARENA_MIN_CHUNK)
-            .for_each_init(<Dim<D> as Morton<D>>::empty_stack, |stack, (row, query)| {
-                let mut force = [T::zero(); D];
-                self.accumulate_forces(query, theta, kernel, &mut force, stack.as_mut());
-                row.copy_from_slice(&force);
+            .for_each_init(<Dim<D> as Morton<D>>::empty_stack, |stack, item| {
+                compute_row(stack.as_mut(), item)
             });
+        #[cfg(not(feature = "parallel"))]
+        {
+            let mut stack = <Dim<D> as Morton<D>>::empty_stack();
+            out.chunks_mut(D)
+                .zip(queries.chunks(D))
+                .for_each(|item| compute_row(stack.as_mut(), item));
+        }
     }
 }
 
@@ -564,7 +600,7 @@ fn check_coms_within_cells<T, W, const D: usize>(
     bits: u32,
 ) -> bool
 where
-    T: Float,
+    T: FloatCore,
     W: MortonWord,
     Dim<D>: Morton<D, Word = W>,
 {
@@ -838,5 +874,106 @@ mod tests {
         // The force magnitude should be nonzero (points are well-separated).
         let mag = (forces[0] * forces[0] + forces[1] * forces[1] + forces[2] * forces[2]).sqrt();
         assert!(mag > 1e-6, "force magnitude should be nonzero");
+    }
+
+    /// Smooth, finite repulsion kernel: `mass / (1 + distance_squared)` on the displacement.
+    /// Linear in `mass`, so a collapsed multi-point leaf keeps the direct reference below exact.
+    fn repulse<const D: usize>(
+        displacement: &[f32; D],
+        distance_squared: f32,
+        mass: f32,
+        _is_leaf: bool,
+        force: &mut [f32; D],
+    ) {
+        let scale = mass / (1.0 + distance_squared);
+        for axis in 0..D {
+            force[axis] += scale * displacement[axis];
+        }
+    }
+
+    /// Direct O(n^2) force on every point from every other under [`repulse`], the exact value a
+    /// theta == 0 Barnes-Hut traversal must reproduce.
+    fn direct_forces<const D: usize>(y: &[f32], n: usize) -> Vec<f32> {
+        let mut out = vec![0.0f32; n * D];
+        for i in 0..n {
+            let mut force = [0.0f32; D];
+            for j in 0..n {
+                if i == j {
+                    continue;
+                }
+                let mut displacement = [0.0f32; D];
+                let mut distance_squared = 0.0f32;
+                for axis in 0..D {
+                    let delta = y[i * D + axis] - y[j * D + axis];
+                    displacement[axis] = delta;
+                    distance_squared += delta * delta;
+                }
+                if distance_squared <= 0.0 {
+                    continue;
+                }
+                repulse::<D>(&displacement, distance_squared, 1.0, true, &mut force);
+            }
+            out[i * D..i * D + D].copy_from_slice(&force);
+        }
+
+        out
+    }
+
+    /// At theta == 0 the traversal descends to every leaf, so `accumulate_all` reproduces the
+    /// direct sum. Runs in whichever build is active, holding the sequential fallback to the same
+    /// reference as the rayon path.
+    #[test]
+    fn accumulate_all_matches_direct_sum_at_theta_zero() {
+        const N: usize = 400;
+        const D: usize = 3;
+        let data = lcg_cloud(N, D, 71);
+        let tree = BarnesHutTree::<f32, u64, D>::new_uniform(&data);
+
+        let mut got = vec![0.0f32; N * D];
+        tree.accumulate_all(&data, 0.0, &repulse::<D>, &mut got);
+        let expected = direct_forces::<D>(&data, N);
+
+        for (component, (&g, &e)) in got.iter().zip(expected.iter()).enumerate() {
+            // Only float reordering separates the two, far below a dropped-point error.
+            let tolerance = 1e-3 * e.abs().max(1.0);
+            assert!(
+                (g - e).abs() <= tolerance,
+                "theta=0 force diverged at component {component}: got {g}, expected {e}"
+            );
+        }
+    }
+
+    /// The driver must reproduce a plain per-row `accumulate_forces` loop bit for bit, since rows
+    /// are independent. Checked at an exact (theta == 0) and an approximating (theta == 0.5) case.
+    #[test]
+    fn accumulate_all_agrees_with_per_row_forces() {
+        const N: usize = 300;
+        const D: usize = 2;
+        let data = lcg_cloud(N, D, 13);
+        let tree = BarnesHutTree::<f32, u64, D>::new_uniform(&data);
+
+        for &theta in &[0.0f32, 0.5] {
+            let mut driver = vec![0.0f32; N * D];
+            tree.accumulate_all(&data, theta, &repulse::<D>, &mut driver);
+
+            let mut per_row = vec![0.0f32; N * D];
+            let mut stack = <Dim<D> as Morton<D>>::empty_stack();
+            for i in 0..N {
+                let mut force = [0.0f32; D];
+                tree.accumulate_forces(
+                    &data[i * D..],
+                    theta,
+                    &repulse::<D>,
+                    &mut force,
+                    stack.as_mut(),
+                );
+                per_row[i * D..i * D + D].copy_from_slice(&force);
+            }
+
+            assert_eq!(
+                driver, per_row,
+                "driver diverged from per-row traversal at theta {theta}"
+            );
+        }
     }
 }

--- a/barnes-hut-tree/src/lib.rs
+++ b/barnes-hut-tree/src/lib.rs
@@ -1,4 +1,7 @@
+#![cfg_attr(not(test), no_std)]
 #![doc = include_str!("../README.md")]
+
+extern crate alloc;
 
 mod arena;
 mod morton;

--- a/barnes-hut-tree/src/morton.rs
+++ b/barnes-hut-tree/src/morton.rs
@@ -15,7 +15,7 @@ mod d5;
 mod d6;
 mod d7;
 
-use num_traits::Float;
+use num_traits::float::FloatCore;
 
 /// Integer type of a Morton code. Covers the operations the arena performs on codes: XOR, shifts,
 /// masks, comparison, and finding the most-significant differing bit.
@@ -25,9 +25,9 @@ pub trait MortonWord:
     + Copy
     + Default
     + Ord
-    + std::ops::BitXor<Output = Self>
-    + std::ops::BitAnd<Output = Self>
-    + std::ops::Shr<u32, Output = Self>
+    + core::ops::BitXor<Output = Self>
+    + core::ops::BitAnd<Output = Self>
+    + core::ops::Shr<u32, Output = Self>
 {
     /// Total number of bits in the type.
     const BITS: u32;
@@ -111,13 +111,13 @@ pub struct Dim<const D: usize>;
 /// `min` is the per-axis lower corner and `inv_scale[axis] = 2^B / extent[axis]` (or `0` for a
 /// degenerate zero-width axis, which collapses to bucket `0`). The result is clamped to
 /// `[0, 2^B - 1]`, so the maximum coordinate maps to the last bucket rather than overflowing.
-pub(crate) fn quantize<T: Float, const D: usize>(
+pub(crate) fn quantize<T: FloatCore, const D: usize>(
     point: &[T; D],
     min: &[T; D],
     inv_scale: &[T; D],
     max_bucket: u32,
 ) -> [u32; D] {
-    std::array::from_fn(|axis| {
+    core::array::from_fn(|axis| {
         let scaled = ((point[axis] - min[axis]) * inv_scale[axis]).floor();
 
         if scaled > T::zero() {

--- a/bhtsne/Cargo.toml
+++ b/bhtsne/Cargo.toml
@@ -30,7 +30,7 @@ wasm_js = ["dep:getrandom", "rand/thread_rng"]
 unsafe_code = "forbid"
 
 [dependencies]
-barnes-hut-tree = { path = "../barnes-hut-tree", version = "=0.1.0" }
+barnes-hut-tree = { path = "../barnes-hut-tree", version = "=0.1.1" }
 csv = { version = "1", optional = true }
 num-traits = "0.2"
 rand_distr = "0.5"

--- a/bhtsne/benches/common/mod.rs
+++ b/bhtsne/benches/common/mod.rs
@@ -3,13 +3,14 @@ use std::{
     ops::{AddAssign, DivAssign, MulAssign, SubAssign},
 };
 
-use num_traits::{AsPrimitive, Float};
+use num_traits::{AsPrimitive, Float, float::FloatCore};
 
 use bhtsne::{FftNum, Neighbor};
 
 /// The scalar bound bundle the t-SNE solver requires, satisfied by both floats.
 pub trait Scalar:
     Float
+    + FloatCore
     + FftNum
     + Send
     + Sync
@@ -24,6 +25,7 @@ pub trait Scalar:
 
 impl<T> Scalar for T where
     T: Float
+        + FloatCore
         + FftNum
         + Send
         + Sync
@@ -58,7 +60,7 @@ pub fn lcg<T: Scalar>(n: usize, dim: usize, mut state: u64) -> Vec<T> {
 pub fn sq_euclidean<T: Scalar>(x: &[T], y: &[T]) -> T {
     x.iter()
         .zip(y)
-        .map(|(xi, yi)| (*xi - *yi).powi(2))
+        .map(|(xi, yi)| Float::powi(*xi - *yi, 2))
         .sum::<T>()
 }
 

--- a/bhtsne/src/lib.rs
+++ b/bhtsne/src/lib.rs
@@ -60,7 +60,7 @@ use std::{
     ops::{AddAssign, DivAssign, MulAssign, SubAssign},
 };
 
-use num_traits::{Float, cast::AsPrimitive};
+use num_traits::{Float, cast::AsPrimitive, float::FloatCore};
 
 use repulsion::{BarnesHutRepulsion, InterpolatedRepulsion, Repulsion};
 
@@ -506,7 +506,7 @@ where
     /// [`barnes_hut`]: tSNE::barnes_hut
     pub fn kl_divergence(&self) -> Option<T>
     where
-        T: FftNum,
+        T: FftNum + FloatCore,
         Dim<D>: Morton<D>,
     {
         let n_samples = self.data.len();
@@ -765,6 +765,7 @@ where
     /// satisfy the [triangle inequality](https://en.wikipedia.org/wiki/Triangle_inequality).
     pub fn barnes_hut<F>(&mut self, theta: T, metric_f: F) -> &mut Self
     where
+        T: FloatCore,
         F: Fn(&U, &U) -> T + Send + Sync,
         Dim<D>: Morton<D>,
     {
@@ -825,6 +826,7 @@ where
         neighbors: &[Vec<Neighbor<T>>],
     ) -> &mut Self
     where
+        T: FloatCore,
         Dim<D>: Morton<D>,
     {
         // Reject a bad theta up front, on the cached path too, matching `barnes_hut`.

--- a/bhtsne/src/repulsion.rs
+++ b/bhtsne/src/repulsion.rs
@@ -11,7 +11,7 @@ use std::{
     ops::{AddAssign, DivAssign, MulAssign, SubAssign},
 };
 
-use num_traits::{Float, cast::AsPrimitive};
+use num_traits::{Float, cast::AsPrimitive, float::FloatCore};
 
 use rustfft::FftNum;
 
@@ -73,7 +73,7 @@ where
 
 impl<T, W, const D: usize> BarnesHutRepulsion<T, W, D>
 where
-    T: Float + Send + Sync + AddAssign,
+    T: Float + FloatCore + Send + Sync + AddAssign,
     W: barnes_hut_tree::MortonWord,
 {
     pub(crate) fn new(theta: T) -> Self {
@@ -88,7 +88,7 @@ where
 
 impl<T, W, const D: usize> Repulsion<T, D> for BarnesHutRepulsion<T, W, D>
 where
-    T: Float + Send + Sync + Sum + AddAssign + SubAssign + MulAssign + DivAssign,
+    T: Float + FloatCore + Send + Sync + Sum + AddAssign + SubAssign + MulAssign + DivAssign,
     W: barnes_hut_tree::MortonWord,
     barnes_hut_tree::Dim<D>: barnes_hut_tree::Morton<D, Word = W>,
 {
@@ -154,7 +154,7 @@ where
         // the fused update multiply instead of dividing per value.
         let q_sum: T = self.q_sums.iter().copied().sum();
 
-        q_sum.recip()
+        Float::recip(q_sum)
     }
 
     fn error(

--- a/bhtsne/src/tsne/mod.rs
+++ b/bhtsne/src/tsne/mod.rs
@@ -18,7 +18,7 @@ use rayon::{
 
 use rand_distr::{Distribution, Normal};
 
-use num_traits::{AsPrimitive, Float};
+use num_traits::{AsPrimitive, Float, float::FloatCore};
 
 use rustfft::FftNum;
 
@@ -647,7 +647,7 @@ pub(crate) fn evaluate_error_approximately<T, const D: usize>(
     theta: T,
 ) -> T
 where
-    T: Float + Send + Sync + Sum + AddAssign + SubAssign + MulAssign + DivAssign,
+    T: Float + FloatCore + Send + Sync + Sum + AddAssign + SubAssign + MulAssign + DivAssign,
     barnes_hut_tree::Dim<D>: barnes_hut_tree::Morton<D>,
 {
     // Get estimate of normalization term.
@@ -676,7 +676,14 @@ where
 
         q_sums.par_iter().map(|sum| *sum).sum::<T>()
     };
-    sparse_kl_divergence::<T, D>(p_rows, p_columns, p_values, y, n_samples, q_sum.recip())
+    sparse_kl_divergence::<T, D>(
+        p_rows,
+        p_columns,
+        p_values,
+        y,
+        n_samples,
+        Float::recip(q_sum),
+    )
 }
 
 /// Evaluate the t-SNE cost for an interpolation (FIt-SNE) fit.


### PR DESCRIPTION
Currently the crate depends on `rayon` unconditionally, and `rayon` pulls in `crossbeam`, one of whose crates does `extern crate std`, so the crate cannot build on bare metal. This makes `rayon` the optional, default-on `parallel` feature and introduces a sequential fallback. With `parallel` off and the default `std` feature dropped, the crate compiles as `no_std` + `alloc`, routing `num-traits` through `libm` via a new `libm` feature.